### PR TITLE
Fixed issue parsing package contains identifier with dots and the word helper

### DIFF
--- a/Source/SimpleParser/SimpleParser.pas
+++ b/Source/SimpleParser/SimpleParser.pas
@@ -5590,6 +5590,14 @@ end;
 procedure TmwSimplePasPar.ContainsIdentifier;
 begin
   Expected(ptIdentifier);
+  while Lexer.TokenID = ptPoint do
+  begin
+    NextToken;
+    if not (Lexer.TokenID in [ptIdentifier,ptHelper]) then
+      Expected(ptIdentifier)
+    else
+      NextToken;
+  end;
 end;
 
 procedure TmwSimplePasPar.ContainsExpression;


### PR DESCRIPTION
Just ran a quick test over a package file, didn't cope with unit names that have dots. After that, if failed on a unit name like VSoft.Test.Helper because Helper is tokenised as a ptHelper keyword (will discuss parser desgin in a separate issue). 
