### PR TITLE
Forward declarations of interfaces are now recoginzed

### DIFF
--- a/Source/DelphiAST.pas
+++ b/Source/DelphiAST.pas
@@ -122,6 +122,7 @@ type
     procedure InheritedStatement; override;
     procedure InheritedVariableReference; override;
     procedure InitializationSection; override;
+    procedure InterfaceForward; override;
     procedure InterfaceGUID; override;
     procedure InterfaceSection; override;
     procedure InterfaceType; override;
@@ -1137,6 +1138,12 @@ begin
   finally
     FStack.Pop;
   end;
+end;
+
+procedure TPasSyntaxTreeBuilder.InterfaceForward;
+begin
+  FStack.Peek.SetAttribute('forwarded', 'true');
+  inherited InterfaceForward;
 end;
 
 procedure TPasSyntaxTreeBuilder.InterfaceGUID;


### PR DESCRIPTION
Forward declarations of classes work well while forward declarations of interfaces didn't. With this change forwarding works wih interfaces too.