### PR TITLE
Fix #98: Exceptionhandlers are not fully supported 

### DIFF
--- a/Source/DelphiAST.pas
+++ b/Source/DelphiAST.pas
@@ -104,6 +104,7 @@ type
     procedure EnumeratedType; override;
     procedure ExceptBlock; override;
     procedure ExceptionHandler; override;
+    procedure ExceptionVariable; override;
     procedure ExportedHeading; override;
     procedure ExportsClause; override;
     procedure ExportsElement; override;
@@ -917,6 +918,18 @@ end;
 procedure TPasSyntaxTreeBuilder.ExceptionHandler;
 begin
   FStack.Push(ntExceptionHandler);
+  try
+    inherited;
+  finally
+    FStack.Pop;
+  end;
+end;
+
+procedure TPasSyntaxTreeBuilder.ExceptionVariable;
+begin
+  FStack.Push(ntVariable);
+  FStack.Push(ntName).SetAttribute(sNAME, Lexer.Token);
+  FStack.Pop;
   try
     inherited;
   finally

--- a/Source/DelphiAST.pas
+++ b/Source/DelphiAST.pas
@@ -939,8 +939,7 @@ end;
 procedure TPasSyntaxTreeBuilder.ExceptionVariable;
 begin
   FStack.Push(ntVariable);
-  FStack.Push(ntName).SetAttribute(sVALUE, Lexer.Token);
-  FStack.Pop;
+  FStack.AddChild(ntName).SetAttribute(sVALUE, Lexer.Token);
   try
     inherited;
   finally

--- a/Source/DelphiAST.pas
+++ b/Source/DelphiAST.pas
@@ -103,6 +103,7 @@ type
     procedure EmptyStatement; override;
     procedure EnumeratedType; override;
     procedure ExceptBlock; override;
+    procedure ExceptionBlockElseBranch; override;
     procedure ExceptionHandler; override;
     procedure ExceptionVariable; override;
     procedure ExportedHeading; override;
@@ -908,6 +909,16 @@ end;
 procedure TPasSyntaxTreeBuilder.ExceptBlock;
 begin
   FStack.Push(ntExcept);
+  try
+    inherited;
+  finally
+    FStack.Pop;
+  end;
+end;
+
+procedure TPasSyntaxTreeBuilder.ExceptionBlockElseBranch;
+begin
+  FStack.Push(ntElse);
   try
     inherited;
   finally

--- a/Source/DelphiAST.pas
+++ b/Source/DelphiAST.pas
@@ -939,7 +939,7 @@ end;
 procedure TPasSyntaxTreeBuilder.ExceptionVariable;
 begin
   FStack.Push(ntVariable);
-  FStack.Push(ntName).SetAttribute(sNAME, Lexer.Token);
+  FStack.Push(ntName).SetAttribute(sVALUE, Lexer.Token);
   FStack.Pop;
   try
     inherited;

--- a/Source/SimpleParser/SimpleParser.pas
+++ b/Source/SimpleParser/SimpleParser.pas
@@ -2350,7 +2350,8 @@ begin
     ptOn:
       begin
         ExceptionHandlerList;
-        ExceptionBlockElseBranch
+        if TokenID = ptElse then
+          ExceptionBlockElseBranch;
       end;
   else
     begin
@@ -2378,13 +2379,8 @@ end;
 
 procedure TmwSimplePasPar.ExceptionBlockElseBranch;
 begin
-  case TokenID of
-    ptElse:
-      begin
-        NextToken;
-        StatementList;
-      end;
-  end;
+  NextToken;
+  StatementList;
 end;
 
 procedure TmwSimplePasPar.ExceptionIdentifier;

--- a/Source/SimpleParser/SimpleParser.pas
+++ b/Source/SimpleParser/SimpleParser.pas
@@ -2395,28 +2395,27 @@ begin
       begin
         ExceptionClassTypeIdentifier;
       end;
+    ptColon:
+      begin
+        ExceptionVariable;
+      end
   else
     begin
-      ExceptionVariable;
-      case Lexer.TokenID of
-        ptColon:
-          begin
-            NextToken;
-            ExceptionClassTypeIdentifier;
-          end;
-      end;
+      ExceptionClassTypeIdentifier;
     end;
   end;
 end;
 
 procedure TmwSimplePasPar.ExceptionClassTypeIdentifier;
 begin
-  QualifiedIdentifier;
+  TypeKind;
 end;
 
 procedure TmwSimplePasPar.ExceptionVariable;
 begin
   Expected(ptIdentifier);
+  Expected(ptColon);
+  ExceptionClassTypeIdentifier;
 end;
 
 procedure TmwSimplePasPar.InlineStatement;

--- a/Test/Snippets/tryexcept.pas
+++ b/Test/Snippets/tryexcept.pas
@@ -1,0 +1,54 @@
+unit tryexcept;
+
+interface
+
+implementation
+
+procedure DoStuff;
+var
+  O: MyUnit.TMyObject;
+begin
+  try
+   DoSomething;
+  except
+    Log('DoSomething failed');
+  end; 
+
+  try
+    DoSomethingElse
+  except
+    on E: Exception do
+    begin
+      LogError(E);
+    end;
+  end;
+  
+  try
+    DoCrazyStuff;
+  except
+  
+    on EFileNotFound do
+    begin
+      LogHint('File not found. Does''nt matter.');
+    end;  
+    
+    on MyUnit.EFileNotFound do
+    begin
+      LogHint('MyUnit file not found. Does''nt matter.');
+    end;  
+    
+    on E: MyUnit.ECriticalError do
+    begin
+      LogError('MyUnit Critical error: ' + E.Message);
+    end;        
+  
+    on E: Exception do
+    begin
+      LogError(E);
+    end
+    else
+      LogError('Unknown error');
+  end;              
+end;
+
+end.


### PR DESCRIPTION
Exceptionhandlers can now contain a node of ntVariable for `on E: Exception do` or a node of ntType for `on Exception do`.
The else branch in `except`block is now also represented in AST. 