### PR TITLE
Attributes use enums instead of strings as keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,86 +1,9 @@
 ### Abstract Syntax Tree Builder for Delphi 
 With DelphiAST you can take real Delphi code and get an abstract syntax tree. One unit at time and without a symbol table though. 
 
-FreePascal and Lazarus compatible.
+This is forked from https://github.com/RomanYankovsky/DelphiAST
 
-#### Sample input
-```delphi
-unit Unit1;
-
-interface
-
-uses
-  Unit2;
-
-function Sum(A, B: Integer): Integer;
-
-implementation
-
-function Sum(A, B: Integer): Integer;
-begin
-  Result := A + B;
-end;
-
-end.
-```
-
-#### Sample outcome
-```xml
-<UNIT line="1" col="1" name="Unit1">
-  <INTERFACE line="3" col="1">
-    <USES line="5" col="1">
-      <UNIT line="6" col="3" name="Unit2"/>
-    </USES>
-    <METHOD line="8" col="1" kind="function" name="Sum">
-      <PARAMETERS line="8" col="13">
-        <PARAMETER line="8" col="14">
-          <NAME line="8" col="14" value="A"/>
-          <TYPE line="8" col="20" name="Integer"/>
-        </PARAMETER>
-        <PARAMETER line="8" col="17">
-          <NAME line="8" col="17" value="B"/>
-          <TYPE line="8" col="20" name="Integer"/>
-        </PARAMETER>
-      </PARAMETERS>
-      <RETURNTYPE line="8" col="30">
-        <TYPE line="8" col="30" name="Integer"/>
-      </RETURNTYPE>
-    </METHOD>
-  </INTERFACE>
-  <IMPLEMENTATION line="10" col="1">
-    <METHOD line="12" col="1" kind="function" name="Sum">
-      <PARAMETERS line="12" col="13">
-        <PARAMETER line="12" col="14">
-          <NAME line="12" col="14" value="A"/>
-          <TYPE line="12" col="20" name="Integer"/>
-        </PARAMETER>
-        <PARAMETER line="12" col="17">
-          <NAME line="12" col="17" value="B"/>
-          <TYPE line="12" col="20" name="Integer"/>
-        </PARAMETER>
-      </PARAMETERS>
-      <RETURNTYPE line="12" col="30">
-        <TYPE line="12" col="30" name="Integer"/>
-      </RETURNTYPE>
-      <STATEMENTS begin_line="13" begin_col="1" end_line="15" end_col="4">
-        <ASSIGN line="14" col="3">
-          <LHS line="14" col="3">
-            <IDENTIFIER line="14" col="3" name="Result"/>
-          </LHS>
-          <RHS line="14" col="13">
-            <EXPRESSION line="14" col="13">
-              <ADD line="14" col="15">
-                <IDENTIFIER line="14" col="13" name="A"/>
-                <IDENTIFIER line="14" col="17" name="B"/>
-              </ADD>
-            </EXPRESSION>
-          </RHS>
-        </ASSIGN>
-      </STATEMENTS>
-    </METHOD>
-  </IMPLEMENTATION>
-</UNIT>
-```
+Please use that branch, not this one.
 
 #### Copyright
 Copyright (c) 2014-2015 Roman Yankovsky (roman@yankovsky.me)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,86 @@
 ### Abstract Syntax Tree Builder for Delphi 
 With DelphiAST you can take real Delphi code and get an abstract syntax tree. One unit at time and without a symbol table though. 
 
-This is forked from https://github.com/RomanYankovsky/DelphiAST
+FreePascal and Lazarus compatible.
 
-Please use that branch, not this one.
+#### Sample input
+```delphi
+unit Unit1;
+
+interface
+
+uses
+  Unit2;
+
+function Sum(A, B: Integer): Integer;
+
+implementation
+
+function Sum(A, B: Integer): Integer;
+begin
+  Result := A + B;
+end;
+
+end.
+```
+
+#### Sample outcome
+```xml
+<UNIT line="1" col="1" name="Unit1">
+  <INTERFACE line="3" col="1">
+    <USES line="5" col="1">
+      <UNIT line="6" col="3" name="Unit2"/>
+    </USES>
+    <METHOD line="8" col="1" kind="function" name="Sum">
+      <PARAMETERS line="8" col="13">
+        <PARAMETER line="8" col="14">
+          <NAME line="8" col="14" value="A"/>
+          <TYPE line="8" col="20" name="Integer"/>
+        </PARAMETER>
+        <PARAMETER line="8" col="17">
+          <NAME line="8" col="17" value="B"/>
+          <TYPE line="8" col="20" name="Integer"/>
+        </PARAMETER>
+      </PARAMETERS>
+      <RETURNTYPE line="8" col="30">
+        <TYPE line="8" col="30" name="Integer"/>
+      </RETURNTYPE>
+    </METHOD>
+  </INTERFACE>
+  <IMPLEMENTATION line="10" col="1">
+    <METHOD line="12" col="1" kind="function" name="Sum">
+      <PARAMETERS line="12" col="13">
+        <PARAMETER line="12" col="14">
+          <NAME line="12" col="14" value="A"/>
+          <TYPE line="12" col="20" name="Integer"/>
+        </PARAMETER>
+        <PARAMETER line="12" col="17">
+          <NAME line="12" col="17" value="B"/>
+          <TYPE line="12" col="20" name="Integer"/>
+        </PARAMETER>
+      </PARAMETERS>
+      <RETURNTYPE line="12" col="30">
+        <TYPE line="12" col="30" name="Integer"/>
+      </RETURNTYPE>
+      <STATEMENTS begin_line="13" begin_col="1" end_line="15" end_col="4">
+        <ASSIGN line="14" col="3">
+          <LHS line="14" col="3">
+            <IDENTIFIER line="14" col="3" name="Result"/>
+          </LHS>
+          <RHS line="14" col="13">
+            <EXPRESSION line="14" col="13">
+              <ADD line="14" col="15">
+                <IDENTIFIER line="14" col="13" name="A"/>
+                <IDENTIFIER line="14" col="17" name="B"/>
+              </ADD>
+            </EXPRESSION>
+          </RHS>
+        </ASSIGN>
+      </STATEMENTS>
+    </METHOD>
+  </IMPLEMENTATION>
+</UNIT>
+```
 
 #### Copyright
 Copyright (c) 2014-2015 Roman Yankovsky (roman@yankovsky.me)

--- a/Source/DelphiAST.Classes.pas
+++ b/Source/DelphiAST.Classes.pas
@@ -16,7 +16,7 @@ type
     function GetHasChildren: Boolean;
     function GetHasAttributes: Boolean;
   protected
-    FAttributes: TDictionary<string, string>;
+    FAttributes: TDictionary<TAttributeName, string>;
     FChildNodes: TObjectList<TSyntaxNode>;
     FTyp: TSyntaxNodeType;
     FParentNode: TSyntaxNode;
@@ -26,9 +26,9 @@ type
 
     function Clone: TSyntaxNode; virtual;
 
-    function GetAttribute(const Key: string): string;
-    function HasAttribute(const Key: string): boolean;
-    procedure SetAttribute(const Key: string; Value: string);
+    function GetAttribute(const Key: TAttributeName): string;
+    function HasAttribute(const Key: TAttributeName): boolean;
+    procedure SetAttribute(const Key: TAttributeName; Value: string);
 
     function AddChild(Node: TSyntaxNode): TSyntaxNode; overload;
     function AddChild(Typ: TSyntaxNodeType): TSyntaxNode; overload;
@@ -36,7 +36,7 @@ type
 
     function FindNode(Typ: TSyntaxNodeType): TSyntaxNode;
 
-    property Attributes: TDictionary<string, string> read FAttributes;
+    property Attributes: TDictionary<TAttributeName, string> read FAttributes;
     property ChildNodes: TObjectList<TSyntaxNode> read FChildNodes;
     property HasAttributes: Boolean read GetHasAttributes;
     property HasChildren: Boolean read GetHasChildren;
@@ -366,7 +366,7 @@ end;
 
 { TSyntaxNode }
 
-procedure TSyntaxNode.SetAttribute(const Key: string; Value: string);
+procedure TSyntaxNode.SetAttribute(const Key: TAttributeName; Value: string);
 begin
   FAttributes.AddOrSetValue(Key, Value);
 end;
@@ -389,7 +389,7 @@ end;
 function TSyntaxNode.Clone: TSyntaxNode;
 var
   ChildNode: TSyntaxNode;
-  Attr: TPair<string, string>;
+  Attr: TPair<TAttributeName, string>;
 begin
   Result := TSyntaxNodeClass(Self.ClassType).Create(FTyp);
 
@@ -407,7 +407,7 @@ constructor TSyntaxNode.Create(Typ: TSyntaxNodeType);
 begin
   inherited Create;
   FTyp := Typ;
-  FAttributes := TDictionary<string, string>.Create;
+  FAttributes := TDictionary<TAttributeName, string>.Create;
   FChildNodes := TObjectList<TSyntaxNode>.Create(True);
   FParentNode := nil;
 end;
@@ -437,7 +437,7 @@ begin
     end;
 end;
 
-function TSyntaxNode.GetAttribute(const Key: string): string;
+function TSyntaxNode.GetAttribute(const Key: TAttributeName): string;
 begin
   if not FAttributes.TryGetValue(Key, Result) then
     Result := '';
@@ -453,7 +453,7 @@ begin
   Result := FChildNodes.Count > 0;
 end;
 
-function TSyntaxNode.HasAttribute(const Key: string): boolean;
+function TSyntaxNode.HasAttribute(const Key: TAttributeName): boolean;
 begin
   result := FAttributes.ContainsKey(key);
 end;

--- a/Source/DelphiAST.Consts.pas
+++ b/Source/DelphiAST.Consts.pas
@@ -136,7 +136,11 @@ type
     anName,
     anVisibility,
     anCallingConvention,
-    anPath
+    anPath,
+    anMethodBinding,
+    anReintroduce,
+    anOverload,
+    anAbstract
   );
 
 const
@@ -283,7 +287,11 @@ const
     'name',
     'visibility',
     'callingconvention',
-    'path'
+    'path',
+    'methodbinding',
+    'reintroduce',
+    'overload',
+    'abstract'
   );
 begin
   Exit(AttributeNameStrings[AttributeName]);

--- a/Source/DelphiAST.Consts.pas
+++ b/Source/DelphiAST.Consts.pas
@@ -128,6 +128,17 @@ type
     ntWrite
   );
 
+  TAttributeName = (
+    anType,
+    anClass,
+    anForwarded,
+    anKind,
+    anName,
+    anVisibility,
+    anCallingConvention,
+    anPath
+  );
+
 const
   SyntaxNodeNames: array [TSyntaxNodeType] of string = (
     'unknown',
@@ -254,15 +265,28 @@ const
     'write'
   );
 
-
 const
-  sCALLINGCONVENTION = 'callingconvention';
   sENUM              = 'enum';
-  sNAME              = 'name';
-  sPATH              = 'path';
   sSUBRANGE          = 'subrange';
-  sTYPE              = 'type';
+
+  function AttributeNameToStr(const AttributeName : TAttributeName) : string;
 
 implementation
+
+function AttributeNameToStr(const AttributeName : TAttributeName) : string;
+const
+  AttributeNameStrings : array[TAttributeName] of string = (
+    'type',
+    'class',
+    'forwarded',
+    'kind',
+    'name',
+    'visibility',
+    'callingconvention',
+    'path'
+  );
+begin
+  Exit(AttributeNameStrings[AttributeName]);
+end;
 
 end.

--- a/Source/DelphiAST.Writer.pas
+++ b/Source/DelphiAST.Writer.pas
@@ -64,7 +64,7 @@ class procedure TSyntaxTreeWriter.NodeToXML(const Builder: TStringBuilder;
   var
     HasChildren: Boolean;
     NewIndent: string;
-    Attr: TPair<string, string>;
+    Attr: TPair<TAttributeName, string>;
     ChildNode: TSyntaxNode;
   begin
     HasChildren := Node.HasChildren;
@@ -91,7 +91,7 @@ class procedure TSyntaxTreeWriter.NodeToXML(const Builder: TStringBuilder;
       Builder.Append(' value="' + TValuedSyntaxNode(Node).Value + '"');
 
     for Attr in Node.Attributes do
-      Builder.Append(' ' + LowerCase(Attr.Key) + '="' + XMLEncode(Attr.Value) + '"');
+      Builder.Append(' ' + AttributeNameToStr(Attr.Key) + '="' + XMLEncode(Attr.Value) + '"');
     if HasChildren then
       Builder.Append('>')
     else

--- a/Source/DelphiAST.pas
+++ b/Source/DelphiAST.pas
@@ -886,8 +886,21 @@ end;
 
 procedure TPasSyntaxTreeBuilder.DirectiveBinding;
 begin
-  assert(false);
-  //!!!FStack.Peek.SetAttribute(Lexer.Token, 'true');
+  // Method bindings:
+  if SameText(Lexer.Token, 'override') or SameText(Lexer.Token, 'virtual')
+    or SameText(Lexer.Token, 'dynamic')
+  then
+    FStack.Peek.SetAttribute(anMethodBinding, Lexer.Token)
+  // Other directives
+  else if SameText(Lexer.Token, 'reintroduce') then
+    FStack.Peek.SetAttribute(anReintroduce, 'true')
+  else if SameText(Lexer.Token, 'overload') then
+    FStack.Peek.SetAttribute(anOverload, 'true')
+  else if SameText(Lexer.Token, 'abstract') then
+    FStack.Peek.SetAttribute(anAbstract, 'true')
+  else
+    assert(false); // Unexpected directive
+
   inherited;
 end;
 

--- a/Source/DelphiAST.pas
+++ b/Source/DelphiAST.pas
@@ -362,7 +362,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.AsmStatement;
 begin
-  FStack.PushCompoundSyntaxNode(ntStatements).SetAttribute('type', 'asm');
+  FStack.PushCompoundSyntaxNode(ntStatements).SetAttribute(anType, 'asm');
   try
     inherited;
     SetCurrentCompoundNodesEndPosition;
@@ -543,7 +543,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.ClassClass;
 begin
-  FStack.Peek.SetAttribute('class', 'true');
+  FStack.Peek.SetAttribute(anClass, 'true');
   inherited;
 end;
 
@@ -589,13 +589,13 @@ end;
 
 procedure TPasSyntaxTreeBuilder.ClassForward;
 begin
-  FStack.Peek.SetAttribute('forwarded', 'true');
+  FStack.Peek.SetAttribute(anForwarded, 'true');
   inherited ClassForward;
 end;
 
 procedure TPasSyntaxTreeBuilder.ClassFunctionHeading;
 begin
-  FStack.Peek.SetAttribute('kind', 'function');
+  FStack.Peek.SetAttribute(anKind, 'function');
   inherited;
 end;
 
@@ -611,7 +611,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.ClassMethod;
 begin
-  FStack.Peek.SetAttribute('class', 'true');
+  FStack.Peek.SetAttribute(anClass, 'true');
   inherited;
 end;
 
@@ -628,7 +628,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.ClassProcedureHeading;
 begin
-  FStack.Peek.SetAttribute('kind', 'procedure');
+  FStack.Peek.SetAttribute(anKind, 'procedure');
   inherited;
 end;
 
@@ -644,7 +644,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.ClassReferenceType;
 begin
-  FStack.Push(ntType).SetAttribute(sTYPE, 'classof');
+  FStack.Push(ntType).SetAttribute(anType, 'classof');
   try
     inherited;
   finally
@@ -658,7 +658,7 @@ var
   i: Integer;
   extracted: Boolean;
 begin
-  FStack.Push(ntType).SetAttribute(sTYPE, 'class');
+  FStack.Push(ntType).SetAttribute(anType, 'class');
   try
     inherited;
   finally
@@ -669,7 +669,7 @@ begin
     begin
       child := classDef.ChildNodes[i];
       extracted := false;
-      if child.HasAttribute('visibility') then
+      if child.HasAttribute(anVisibility) then
         vis := child
       else if assigned(vis) then
       begin
@@ -685,7 +685,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.ConstParameter;
 begin
-  FStack.Push(ntParameters).SetAttribute('kind', 'const');
+  FStack.Push(ntParameters).SetAttribute(anKind, 'const');
   try
     inherited;
   finally
@@ -695,8 +695,8 @@ end;
 
 procedure TPasSyntaxTreeBuilder.ConstructorName;
 begin
-  FStack.Peek.SetAttribute('kind', 'constructor');
-  FStack.Peek.SetAttribute('name', Lexer.Token);
+  FStack.Peek.SetAttribute(anKind, 'constructor');
+  FStack.Peek.SetAttribute(anName, Lexer.Token);
   inherited;
 end;
 
@@ -879,20 +879,21 @@ end;
 
 procedure TPasSyntaxTreeBuilder.DestructorName;
 begin
-  FStack.Peek.SetAttribute('kind', 'destructor');
-  FStack.Peek.SetAttribute('name', Lexer.Token);
+  FStack.Peek.SetAttribute(anKind, 'destructor');
+  FStack.Peek.SetAttribute(anName, Lexer.Token);
   inherited;
 end;
 
 procedure TPasSyntaxTreeBuilder.DirectiveBinding;
 begin
-  FStack.Peek.SetAttribute(Lexer.Token, 'true');
+  assert(false);
+  //!!!FStack.Peek.SetAttribute(Lexer.Token, 'true');
   inherited;
 end;
 
 procedure TPasSyntaxTreeBuilder.DirectiveCalling;
 begin
-  FStack.Peek.SetAttribute(sCALLINGCONVENTION, Lexer.Token);
+  FStack.Peek.SetAttribute(anCallingConvention, Lexer.Token);
   inherited;
 end;
 
@@ -924,7 +925,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.EnumeratedType;
 begin
-  FStack.Push(ntType).SetAttribute(sNAME, sENUM);
+  FStack.Push(ntType).SetAttribute(anName, sENUM);
   try
     inherited;
   finally
@@ -996,7 +997,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.ExportsElement;
 begin
-  FStack.Push(ntElement).SetAttribute('name', Lexer.Token);
+  FStack.Push(ntElement).SetAttribute(anName, Lexer.Token);
   try
     inherited;
   finally
@@ -1080,7 +1081,7 @@ begin
     for ParamList in Params.ChildNodes do
     begin
       TypeInfo := ParamList.FindNode(ntType);
-      ParamKind := ParamList.GetAttribute('kind');
+      ParamKind := ParamList.GetAttribute(anKind);
       ParamExpr := ParamList.FindNode(ntExpression);
 
       for Param in ParamList.ChildNodes do
@@ -1090,7 +1091,7 @@ begin
 
         FStack.Push(ntParameter);
         if ParamKind <> '' then
-          FStack.Peek.SetAttribute('kind', ParamKind);
+          FStack.Peek.SetAttribute(anKind, ParamKind);
 
         FStack.Peek.Col  := Param.Col;
         FStack.Peek.Line := Param.Line;
@@ -1163,7 +1164,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.FunctionHeading;
 begin
-  FStack.Peek.SetAttribute('kind', 'function');
+  FStack.Peek.SetAttribute(anKind, 'function');
   inherited;
 end;
 
@@ -1195,7 +1196,7 @@ begin
           begin
             if TypeParams <> '' then
               TypeParams := TypeParams + ',';
-            TypeParams := TypeParams + TypeNode.GetAttribute(sNAME);
+            TypeParams := TypeParams + TypeNode.GetAttribute(anName);
           end;
         end;
 
@@ -1209,7 +1210,7 @@ begin
     end;
   finally
     FStack.Pop;
-    FStack.Peek.SetAttribute(sNAME, FullName);
+    FStack.Peek.SetAttribute(anName, FullName);
     FStack.Peek.DeleteChild(nameNode);
   end;
 end;
@@ -1226,7 +1227,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.Identifier;
 begin
-  FStack.AddChild(ntIdentifier).SetAttribute(sNAME, Lexer.Token);
+  FStack.AddChild(ntIdentifier).SetAttribute(anName, Lexer.Token);
   inherited;
 end;
 
@@ -1304,7 +1305,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.InterfaceForward;
 begin
-  FStack.Peek.SetAttribute('forwarded', 'true');
+  FStack.Peek.SetAttribute(anForwarded, 'true');
   inherited InterfaceForward;
 end;
 
@@ -1331,7 +1332,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.InterfaceType;
 begin
-  FStack.Push(ntType).SetAttribute(sTYPE, 'interface');
+  FStack.Push(ntType).SetAttribute(anType, 'interface');
   try
     inherited;
   finally
@@ -1359,13 +1360,13 @@ begin
 
     if Assigned(NameNode) then
     begin
-      FStack.Peek.SetAttribute(sNAME, NameNode.GetAttribute(sNAME));
+      FStack.Peek.SetAttribute(anName, NameNode.GetAttribute(anName));
       FStack.Peek.DeleteChild(NameNode);
     end;
 
     if PathNode is TValuedSyntaxNode then
     begin
-      FStack.Peek.SetAttribute(sPATH, TValuedSyntaxNode(PathNode).Value);
+      FStack.Peek.SetAttribute(anPath, TValuedSyntaxNode(PathNode).Value);
       FStack.Peek.DeleteChild(PathNode);
     end;
   finally
@@ -1386,7 +1387,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.MethodKind;
 begin
-  FStack.Peek.SetAttribute('kind', LowerCase(Lexer.Token));
+  FStack.Peek.SetAttribute(anKind, LowerCase(Lexer.Token));
   inherited;
 end;
 
@@ -1426,7 +1427,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.NilToken;
 begin
-  FStack.AddChild(ntLiteral).SetAttribute(sTYPE, 'nil');
+  FStack.AddChild(ntLiteral).SetAttribute(anType, 'nil');
   inherited;
 end;
 
@@ -1441,7 +1442,7 @@ var
   Node: TSyntaxNode;
 begin
   Node := FStack.AddValuedChild(ntLiteral, Lexer.Token);
-  Node.SetAttribute(sTYPE, 'numeric');
+  Node.SetAttribute(anType, 'numeric');
   inherited;
 end;
 
@@ -1460,7 +1461,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.OutParameter;
 begin
-  FStack.Push(ntParameters).SetAttribute('kind', 'out');
+  FStack.Push(ntParameters).SetAttribute(anKind, 'out');
   try
     inherited;
   finally
@@ -1492,7 +1493,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.PointerType;
 begin
-  FStack.Push(ntType).SetAttribute(sTYPE, 'pointer');
+  FStack.Push(ntType).SetAttribute(anType, 'pointer');
   try
     inherited;
   finally
@@ -1512,7 +1513,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.ProceduralType;
 begin
-  FStack.Push(ntType).SetAttribute(sNAME, Lexer.Token);
+  FStack.Push(ntType).SetAttribute(anName, Lexer.Token);
   try
     inherited;
   finally
@@ -1533,19 +1534,19 @@ end;
 
 procedure TPasSyntaxTreeBuilder.ProcedureHeading;
 begin
-  FStack.Peek.SetAttribute('kind', 'procedure');
+  FStack.Peek.SetAttribute(anKind, 'procedure');
   inherited;
 end;
 
 procedure TPasSyntaxTreeBuilder.ProcedureProcedureName;
 begin
-  FStack.Peek.SetAttribute(sNAME, Lexer.Token);
+  FStack.Peek.SetAttribute(anName, Lexer.Token);
   inherited;
 end;
 
 procedure TPasSyntaxTreeBuilder.PropertyName;
 begin
-  FStack.Peek.SetAttribute('name', Lexer.Token);
+  FStack.Peek.SetAttribute(anName, Lexer.Token);
   inherited PropertyName;
 end;
 
@@ -1575,7 +1576,7 @@ var
 begin
   Node := FStack.PushValuedNode(ntField, Lexer.Token);
   try
-    Node.SetAttribute(sTYPE, 'name');
+    Node.SetAttribute(anType, 'name');
     inherited;
   finally
     FStack.Pop;
@@ -1643,7 +1644,7 @@ begin
       FStack.Pop;
     end;
 
-    FStack.AddChild(ntPackage).SetAttribute(sNAME, NodeListToString(NamesNode));
+    FStack.AddChild(ntPackage).SetAttribute(anName, NodeListToString(NamesNode));
   finally
     NamesNode.Free;
   end;
@@ -1651,7 +1652,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.RequiresIdentifierId;
 begin
-  FStack.AddChild(ntUnknown, False).SetAttribute(sNAME, Lexer.Token);
+  FStack.AddChild(ntUnknown, False).SetAttribute(anName, Lexer.Token);
   inherited;
 end;
 
@@ -1732,7 +1733,7 @@ begin
   begin
     if Result <> '' then
       Result := Result + '.';
-    Result := Result + NamePartNode.Attributes[sNAME];
+    Result := Result + NamePartNode.Attributes[anName];
   end;
 end;
 
@@ -1844,7 +1845,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.SimpleType;
 begin
-  FStack.Push(ntType).SetAttribute(sNAME, Lexer.Token);
+  FStack.Push(ntType).SetAttribute(anName, Lexer.Token);
   try
     inherited;
   finally
@@ -1896,7 +1897,7 @@ begin
   end;
 
   Node := FStack.AddValuedChild(ntLiteral, Str);
-  Node.SetAttribute(sTYPE, 'string');
+  Node.SetAttribute(anType, 'string');
 end;
 
 procedure TPasSyntaxTreeBuilder.StringConstSimple;
@@ -1908,7 +1909,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.StringType;
 begin
-  FStack.Push(ntType).SetAttribute(sNAME, Lexer.Token);
+  FStack.Push(ntType).SetAttribute(anName, Lexer.Token);
   try
     inherited;
   finally
@@ -1918,7 +1919,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.StructuredType;
 begin
-  FStack.Push(ntType).SetAttribute(sTYPE, Lexer.Token);
+  FStack.Push(ntType).SetAttribute(anType, Lexer.Token);
   try
     inherited;
   finally
@@ -1928,7 +1929,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.SubrangeType;
 begin
-  FStack.Push(ntType).SetAttribute(sNAME, sSUBRANGE);
+  FStack.Push(ntType).SetAttribute(anName, sSUBRANGE);
   try
     inherited;
   finally
@@ -1968,7 +1969,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.TypeDeclaration;
 begin
-  FStack.PushCompoundSyntaxNode(ntTypeDecl).SetAttribute(sNAME, Lexer.Token);
+  FStack.PushCompoundSyntaxNode(ntTypeDecl).SetAttribute(anName, Lexer.Token);
   try
     inherited;
     SetCurrentCompoundNodesEndPosition;
@@ -1991,7 +1992,7 @@ begin
     InnerTypeNode := TypeNode.FindNode(ntType);    
     if Assigned(InnerTypeNode) then
     begin
-      InnerTypeName := InnerTypeNode.GetAttribute(sNAME);
+      InnerTypeName := InnerTypeNode.GetAttribute(anName);
       for SubNode in InnerTypeNode.ChildNodes do 
         TypeNode.AddChild(SubNode.Clone);
         
@@ -2007,7 +2008,7 @@ begin
         if TypeName <> '' then
           TypeName := '.' + TypeName;
           
-        TypeName := SubNode.GetAttribute(sNAME) + TypeName;
+        TypeName := SubNode.GetAttribute(anName) + TypeName;
         TypeNode.DeleteChild(SubNode);
       end;       
     end;
@@ -2016,7 +2017,7 @@ begin
       TypeName := '.' + TypeName;   
     TypeName := InnerTypeName + TypeName;  
       
-    TypeNode.SetAttribute(sNAME, TypeName); 
+    TypeNode.SetAttribute(anName, TypeName);
    
   finally
     FStack.Pop;
@@ -2089,7 +2090,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.TypeSimple;
 begin
-  FStack.Push(ntType).SetAttribute(sNAME, Lexer.Token); 
+  FStack.Push(ntType).SetAttribute(anName, Lexer.Token);
   try
     inherited;
   finally
@@ -2112,7 +2113,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.UnitId;
 begin
-  FStack.AddChild(ntUnknown, False).SetAttribute(sNAME, Lexer.Token);
+  FStack.AddChild(ntUnknown, False).SetAttribute(anName, Lexer.Token);
   inherited;
 end;
 
@@ -2129,7 +2130,7 @@ begin
       FStack.Pop;
     end;
 
-    FStack.Peek.SetAttribute(sNAME, NodeListToString(NamesNode));
+    FStack.Peek.SetAttribute(anName, NodeListToString(NamesNode));
   finally
     NamesNode.Free;
   end;
@@ -2152,7 +2153,7 @@ begin
     end;
 
     UnitNode := FStack.AddChild(ntUnit);
-    UnitNode.SetAttribute(sNAME, NodeListToString(NamesNode));
+    UnitNode.SetAttribute(anName, NodeListToString(NamesNode));
     UnitNode.Col  := Position.X;
     UnitNode.Line := Position.Y;
   finally
@@ -2189,7 +2190,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.VarParameter;
 begin
-  FStack.Push(ntParameters).SetAttribute('kind', 'var');
+  FStack.Push(ntParameters).SetAttribute(anKind, 'var');
   try
     inherited;
   finally
@@ -2248,7 +2249,7 @@ procedure TPasSyntaxTreeBuilder.VisibilityPrivate;
 begin
   FStack.Push(ntPrivate);
   try
-    FStack.Peek.SetAttribute('visibility', 'true');
+    FStack.Peek.SetAttribute(anVisibility, 'true');
     inherited;
   finally
     FStack.Pop;
@@ -2259,7 +2260,7 @@ procedure TPasSyntaxTreeBuilder.VisibilityProtected;
 begin
   FStack.Push(ntProtected);
   try
-    FStack.Peek.SetAttribute('visibility', 'true');
+    FStack.Peek.SetAttribute(anVisibility, 'true');
     inherited;
   finally
     FStack.Pop;
@@ -2270,7 +2271,7 @@ procedure TPasSyntaxTreeBuilder.VisibilityPublic;
 begin
   FStack.Push(ntPublic);
   try
-    FStack.Peek.SetAttribute('visibility', 'true');
+    FStack.Peek.SetAttribute(anVisibility, 'true');
     inherited;
   finally
     FStack.Pop;
@@ -2281,7 +2282,7 @@ procedure TPasSyntaxTreeBuilder.VisibilityPublished;
 begin
   FStack.Push(ntPublished);
   try
-    FStack.Peek.SetAttribute('visibility', 'true');
+    FStack.Peek.SetAttribute(anVisibility, 'true');
     inherited;
   finally
     FStack.Pop;


### PR DESCRIPTION
A syntax node's Attributes[] dictionary (and related methods) now use an enum for the attribute name instead of a string.

This is unlikely to reduce string memory usage much, since the compiler merges identical compile-time strings, but is a plus for correctness (compiler catches spelling errors) and is neater.  It is also a good basis for upcoming code to merge all attribute values - coming soon :)