### PR TITLE
String cache: reduce string memory usage and unique strings used by attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,86 +1,9 @@
 ### Abstract Syntax Tree Builder for Delphi 
 With DelphiAST you can take real Delphi code and get an abstract syntax tree. One unit at time and without a symbol table though. 
 
-FreePascal and Lazarus compatible.
+This is forked from https://github.com/RomanYankovsky/DelphiAST
 
-#### Sample input
-```delphi
-unit Unit1;
-
-interface
-
-uses
-  Unit2;
-
-function Sum(A, B: Integer): Integer;
-
-implementation
-
-function Sum(A, B: Integer): Integer;
-begin
-  Result := A + B;
-end;
-
-end.
-```
-
-#### Sample outcome
-```xml
-<UNIT line="1" col="1" name="Unit1">
-  <INTERFACE line="3" col="1">
-    <USES line="5" col="1">
-      <UNIT line="6" col="3" name="Unit2"/>
-    </USES>
-    <METHOD line="8" col="1" kind="function" name="Sum">
-      <PARAMETERS line="8" col="13">
-        <PARAMETER line="8" col="14">
-          <NAME line="8" col="14" value="A"/>
-          <TYPE line="8" col="20" name="Integer"/>
-        </PARAMETER>
-        <PARAMETER line="8" col="17">
-          <NAME line="8" col="17" value="B"/>
-          <TYPE line="8" col="20" name="Integer"/>
-        </PARAMETER>
-      </PARAMETERS>
-      <RETURNTYPE line="8" col="30">
-        <TYPE line="8" col="30" name="Integer"/>
-      </RETURNTYPE>
-    </METHOD>
-  </INTERFACE>
-  <IMPLEMENTATION line="10" col="1">
-    <METHOD line="12" col="1" kind="function" name="Sum">
-      <PARAMETERS line="12" col="13">
-        <PARAMETER line="12" col="14">
-          <NAME line="12" col="14" value="A"/>
-          <TYPE line="12" col="20" name="Integer"/>
-        </PARAMETER>
-        <PARAMETER line="12" col="17">
-          <NAME line="12" col="17" value="B"/>
-          <TYPE line="12" col="20" name="Integer"/>
-        </PARAMETER>
-      </PARAMETERS>
-      <RETURNTYPE line="12" col="30">
-        <TYPE line="12" col="30" name="Integer"/>
-      </RETURNTYPE>
-      <STATEMENTS begin_line="13" begin_col="1" end_line="15" end_col="4">
-        <ASSIGN line="14" col="3">
-          <LHS line="14" col="3">
-            <IDENTIFIER line="14" col="3" name="Result"/>
-          </LHS>
-          <RHS line="14" col="13">
-            <EXPRESSION line="14" col="13">
-              <ADD line="14" col="15">
-                <IDENTIFIER line="14" col="13" name="A"/>
-                <IDENTIFIER line="14" col="17" name="B"/>
-              </ADD>
-            </EXPRESSION>
-          </RHS>
-        </ASSIGN>
-      </STATEMENTS>
-    </METHOD>
-  </IMPLEMENTATION>
-</UNIT>
-```
+Please use that branch, not this one.
 
 #### Copyright
 Copyright (c) 2014-2015 Roman Yankovsky (roman@yankovsky.me)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,86 @@
 ### Abstract Syntax Tree Builder for Delphi 
 With DelphiAST you can take real Delphi code and get an abstract syntax tree. One unit at time and without a symbol table though. 
 
-This is forked from https://github.com/RomanYankovsky/DelphiAST
+FreePascal and Lazarus compatible.
 
-Please use that branch, not this one.
+#### Sample input
+```delphi
+unit Unit1;
+
+interface
+
+uses
+  Unit2;
+
+function Sum(A, B: Integer): Integer;
+
+implementation
+
+function Sum(A, B: Integer): Integer;
+begin
+  Result := A + B;
+end;
+
+end.
+```
+
+#### Sample outcome
+```xml
+<UNIT line="1" col="1" name="Unit1">
+  <INTERFACE line="3" col="1">
+    <USES line="5" col="1">
+      <UNIT line="6" col="3" name="Unit2"/>
+    </USES>
+    <METHOD line="8" col="1" kind="function" name="Sum">
+      <PARAMETERS line="8" col="13">
+        <PARAMETER line="8" col="14">
+          <NAME line="8" col="14" value="A"/>
+          <TYPE line="8" col="20" name="Integer"/>
+        </PARAMETER>
+        <PARAMETER line="8" col="17">
+          <NAME line="8" col="17" value="B"/>
+          <TYPE line="8" col="20" name="Integer"/>
+        </PARAMETER>
+      </PARAMETERS>
+      <RETURNTYPE line="8" col="30">
+        <TYPE line="8" col="30" name="Integer"/>
+      </RETURNTYPE>
+    </METHOD>
+  </INTERFACE>
+  <IMPLEMENTATION line="10" col="1">
+    <METHOD line="12" col="1" kind="function" name="Sum">
+      <PARAMETERS line="12" col="13">
+        <PARAMETER line="12" col="14">
+          <NAME line="12" col="14" value="A"/>
+          <TYPE line="12" col="20" name="Integer"/>
+        </PARAMETER>
+        <PARAMETER line="12" col="17">
+          <NAME line="12" col="17" value="B"/>
+          <TYPE line="12" col="20" name="Integer"/>
+        </PARAMETER>
+      </PARAMETERS>
+      <RETURNTYPE line="12" col="30">
+        <TYPE line="12" col="30" name="Integer"/>
+      </RETURNTYPE>
+      <STATEMENTS begin_line="13" begin_col="1" end_line="15" end_col="4">
+        <ASSIGN line="14" col="3">
+          <LHS line="14" col="3">
+            <IDENTIFIER line="14" col="3" name="Result"/>
+          </LHS>
+          <RHS line="14" col="13">
+            <EXPRESSION line="14" col="13">
+              <ADD line="14" col="15">
+                <IDENTIFIER line="14" col="13" name="A"/>
+                <IDENTIFIER line="14" col="17" name="B"/>
+              </ADD>
+            </EXPRESSION>
+          </RHS>
+        </ASSIGN>
+      </STATEMENTS>
+    </METHOD>
+  </IMPLEMENTATION>
+</UNIT>
+```
 
 #### Copyright
 Copyright (c) 2014-2015 Roman Yankovsky (roman@yankovsky.me)

--- a/Source/DelphiAST.Classes.pas
+++ b/Source/DelphiAST.Classes.pas
@@ -121,6 +121,7 @@ type
     destructor Destroy; override;
 
     function Add(const Value : string) : NativeUInt;
+    function AddAndGet(const P : PChar; const Length : Integer) : string;
     function Get(const ID : NativeUInt) : string;
     procedure Clear;
     procedure ByUsage(InOrder : TList<TStringRec>);
@@ -663,6 +664,14 @@ begin
   finally
     Item.Free;
   end;
+end;
+
+function TStringCache.AddAndGet(const P : PChar; const Length : Integer) : string;
+var
+  SearchStr : string;
+begin
+  SetString(SearchStr, P, Length);
+  Result := Get(Add(SearchStr));
 end;
 
 function TStringCache.Get(const ID: NativeUInt): string;

--- a/Source/DelphiAST.Classes.pas
+++ b/Source/DelphiAST.Classes.pas
@@ -5,10 +5,13 @@ unit DelphiAST.Classes;
 interface
 
 uses
-  Generics.Collections, SimpleParser.Lexer.Types, DelphiAST.Consts;
+  Generics.Collections, SimpleParser.Lexer.Types, DelphiAST.Consts,
+  Generics.Defaults;
 
 type
   TSyntaxNodeClass = class of TSyntaxNode;
+  TStringCache = class;
+  TStringCacheDictionary<TKey> = class;
   TSyntaxNode = class
   private
     FCol: Integer;
@@ -16,7 +19,7 @@ type
     function GetHasChildren: Boolean;
     function GetHasAttributes: Boolean;
   protected
-    FAttributes: TDictionary<TAttributeName, string>;
+    FAttributes: TStringCacheDictionary<TAttributeName>;
     FChildNodes: TObjectList<TSyntaxNode>;
     FTyp: TSyntaxNodeType;
     FParentNode: TSyntaxNode;
@@ -36,7 +39,7 @@ type
 
     function FindNode(Typ: TSyntaxNodeType): TSyntaxNode;
 
-    property Attributes: TDictionary<TAttributeName, string> read FAttributes;
+    property Attributes: TStringCacheDictionary<TAttributeName> read FAttributes;
     property ChildNodes: TObjectList<TSyntaxNode> read FChildNodes;
     property HasAttributes: Boolean read GetHasAttributes;
     property HasChildren: Boolean read GetHasChildren;
@@ -77,10 +80,90 @@ type
     class procedure RawNodeListToTree(RawParentNode: TSyntaxNode; RawNodeList: TList<TSyntaxNode>; NewRoot: TSyntaxNode); static;
   end;
 
+  TStringCache = class
+  type
+    TStringRec = class
+    strict private
+      FValue : string;
+      FUsageCount : NativeUInt;
+    public
+      constructor Create(const AValue : string);
+      procedure IncUsageCount;
+      property UsageCount : NativeUInt read FUsageCount;
+      property Value : string read FValue;
+    end;
+  private
+    type
+      TStringRecValueEqualityComparer = class(TEqualityComparer<TStringRec>)
+      private
+        FStringComparer : IEqualityComparer<string>;
+      public
+        constructor Create();
+        function Equals(const Left, Right: TStringRec): Boolean; overload; override;
+        function GetHashCode(const Value: TStringRec): Integer; overload; override;
+      end;
+      TStringRecUsageComparer = class(TInterfacedObject, IComparer<TStringRec>)
+        function Compare(const Left, Right: TStringRec): Integer;
+      end;
+  strict private
+    FStringToId : TDictionary<TStringRec, NativeUInt>;
+
+    class var FInstance : TStringCache;
+    class constructor ClassCreate;
+    class destructor ClassDestroy;
+  private
+    FIdToString : TList<TStringRec>; // ID is index
+  public
+    constructor Create;
+    destructor Destroy; override;
+
+    function Add(const Value : string) : NativeUInt;
+    function Get(const ID : NativeUInt) : string;
+    procedure Clear;
+    procedure ByUsage(InOrder : TList<TStringRec>);
+
+    class property Instance : TStringCache read FInstance;
+  end;
+
+  TStringCacheDictionary<TKey> = class(TEnumerable<TPair<TKey, string>>)
+  strict private
+    type
+      TKeyStringEnumerator = class(TEnumerator<TPair<TKey,string>>)
+      private
+        FDictionary: TStringCacheDictionary<TKey>;
+        FInternalEnum : TDictionary<TKey, NativeUInt>.TPairEnumerator;
+        function GetCurrent: TPair<TKey, string>;
+      protected
+        function DoGetCurrent: TPair<TKey, string>; override;
+        function DoMoveNext: Boolean; override;
+      public
+        constructor Create(const ADictionary: TStringCacheDictionary<TKey>);
+      end;
+  private
+    FKeyToId : TDictionary<TKey, NativeUInt>;
+
+    function GetItem(const Key: TKey): string;
+    procedure SetItem(const Key: TKey; const Value: string);
+    function GetCount : Integer;
+  protected
+    function DoGetEnumerator: TEnumerator<TPair<TKey, string>>; override;
+  public
+    constructor Create;
+    destructor Destroy; override;
+
+    function TryGetValue(const Key: TKey; out Value: string): Boolean;
+    procedure AddOrSetValue(const Key: TKey; const Value: string);
+    function ContainsKey(const Key: TKey): Boolean;
+    function ToArray: TArray<TPair<TKey, string>>; override;
+
+    property Items[const Key: TKey]: string read GetItem write SetItem; default;
+    property Count: Integer read GetCount;
+  end;
+
 implementation
 
 uses
-  SysUtils;
+  SysUtils, System.Types;
 
 type
   TOperatorKind = (okUnary, okBinary);
@@ -407,7 +490,7 @@ constructor TSyntaxNode.Create(Typ: TSyntaxNodeType);
 begin
   inherited Create;
   FTyp := Typ;
-  FAttributes := TDictionary<TAttributeName, string>.Create;
+  FAttributes := TStringCacheDictionary<TAttributeName>.Create;
   FChildNodes := TObjectList<TSyntaxNode>.Create(True);
   FParentNode := nil;
 end;
@@ -475,6 +558,224 @@ begin
   Result := inherited;
 
   TValuedSyntaxNode(Result).Value := Self.Value;
+end;
+
+{ TStringCache.TStringRecValueEqualityComparer }
+
+constructor TStringCache.TStringRecValueEqualityComparer.Create;
+begin
+  inherited Create();
+  FStringComparer := TEqualityComparer<string>.Default;
+end;
+
+function TStringCache.TStringRecValueEqualityComparer.Equals(const Left,
+  Right: TStringRec): Boolean;
+begin
+  // Compare by the string it holds only
+  Result := FStringComparer.Equals(Left.Value, Right.Value);
+end;
+
+function TStringCache.TStringRecValueEqualityComparer.GetHashCode(
+  const Value: TStringRec): Integer;
+begin
+  // Compare by the string it holds only
+  Result := FStringComparer.GetHashCode(Value.Value);
+end;
+
+{ TStringCache.TStringRecUsageComparer }
+
+function TStringCache.TStringRecUsageComparer.Compare(const Left,
+  Right: TStringRec): Integer;
+begin
+  if Left.UsageCount < Right.UsageCount then
+    Exit(LessThanValue)
+  else if Left.UsageCount > Right.UsageCount then
+    Exit(GreaterThanValue)
+  else // Usage is the same, sort by string
+    Exit(TComparer<string>.Default.Compare(Left.Value, Right.Value));
+end;
+
+{ TStringCache }
+
+class constructor TStringCache.ClassCreate;
+begin
+  FInstance := TStringCache.Create;
+end;
+
+class destructor TStringCache.ClassDestroy;
+begin
+  FInstance.Free;
+end;
+
+constructor TStringCache.Create;
+begin
+  inherited;
+  FStringToId := TDictionary<TStringRec, NativeUInt>.Create(
+    TStringCache.TStringRecValueEqualityComparer.Create);
+  FIdToString := TList<TStringRec>.Create;
+
+  Add(''); // Empty string is always item 0
+end;
+
+destructor TStringCache.Destroy;
+begin
+  Clear;
+  FStringToId.Free;
+  FIdToString.Free;
+  inherited;
+end;
+
+function TStringCache.Add(const Value: string): NativeUInt;
+var
+  Item : TStringRec;
+begin
+  Result := 0;
+  Item := TStringRec.Create(Value);
+  try
+    if FStringToId.TryGetValue(Item, Result) then begin
+      // Already exists. Increment the usage count of the existing one, and return
+      FIdToString[Result].IncUsageCount;
+      Exit; // item will be freed in finally
+    end;
+
+    // Item does not yet exist
+    Result := FIdToString.Add(Item);
+    FStringToId.Add(Item, Result);
+    Item := nil; // Do not free in finally, newly added
+  finally
+    Item.Free;
+  end;
+end;
+
+function TStringCache.Get(const ID: NativeUInt): string;
+begin
+  if ID < NativeUInt(FIdToString.Count) then
+    Exit(FIdToString[ID].Value)
+  else
+    raise Exception.Create(Format('String cache entry with ID %d does not exist', [ID]));
+end;
+
+procedure TStringCache.Clear;
+var
+  I : Integer;
+begin
+  // One instance of TStringRec, but stored in two lists. Free from only one
+  for I := 0 to Pred(FIdToString.Count) do
+    FIdToString[I].Free;
+
+  FStringToId.Clear;
+  FIdToString.Clear;
+end;
+
+procedure TStringCache.ByUsage(InOrder: TList<TStringRec>);
+begin
+  InOrder.InsertRange(0, FIdToString);
+  InOrder.Sort(TStringCache.TStringRecUsageComparer.Create);
+end;
+
+{ TStringCache.TStringRec }
+
+constructor TStringCache.TStringRec.Create(const AValue: string);
+begin
+  inherited Create;
+  FValue := AValue;
+  FUsageCount := 1;
+end;
+
+procedure TStringCache.TStringRec.IncUsageCount;
+begin
+  Inc(FUsageCount);
+end;
+
+{ TStringCacheDictionary<TKey> }
+
+constructor TStringCacheDictionary<TKey>.Create;
+begin
+  inherited;
+  FKeyToId := TDictionary<TKey, NativeUInt>.Create;
+end;
+
+destructor TStringCacheDictionary<TKey>.Destroy;
+begin
+  FKeyToId.Free;
+  inherited;
+end;
+
+function TStringCacheDictionary<TKey>.GetItem(const Key: TKey): string;
+var
+  ID : NativeUInt;
+begin
+  if FKeyToId.TryGetValue(Key, ID) then
+    Result := TStringCache.Instance.Get(ID)
+  else
+    Result := '';
+end;
+
+procedure TStringCacheDictionary<TKey>.SetItem(const Key: TKey; const Value: string);
+begin
+  FKeyToId.AddOrSetValue(Key, TStringCache.Instance.Add(Value));
+end;
+
+function TStringCacheDictionary<TKey>.GetCount : Integer;
+begin
+  Result := FKeyToId.Count;
+end;
+
+function TStringCacheDictionary<TKey>.TryGetValue(const Key: TKey; out Value: string): Boolean;
+var
+  ID : NativeUInt;
+begin
+  Result := FKeyToId.TryGetValue(Key, ID);
+  if Result then
+    Value := TStringCache.Instance.Get(ID);
+end;
+
+procedure TStringCacheDictionary<TKey>.AddOrSetValue(const Key: TKey; const Value: string);
+begin
+  SetItem(Key, Value);
+end;
+
+function TStringCacheDictionary<TKey>.ContainsKey(const Key: TKey): Boolean;
+begin
+  Result := FKeyToId.ContainsKey(Key);
+end;
+
+function TStringCacheDictionary<TKey>.ToArray: TArray<TPair<TKey, string>>;
+begin
+  Result := ToArrayImpl(Count);
+end;
+
+function TStringCacheDictionary<TKey>.DoGetEnumerator: TEnumerator<TPair<TKey, string>>;
+begin
+  Result := TKeyStringEnumerator.Create(Self);
+end;
+
+{ TStringCacheDictionary<TKey>.TKeyStringEnumerator }
+
+constructor TStringCacheDictionary<TKey>.TKeyStringEnumerator.Create(const ADictionary: TStringCacheDictionary<TKey>);
+begin
+  inherited Create();
+  FDictionary := ADictionary;
+  FInternalEnum := FDictionary.FKeyToId.GetEnumerator;
+end;
+
+function TStringCacheDictionary<TKey>.TKeyStringEnumerator.GetCurrent: TPair<TKey, string>;
+begin
+  Result := DoGetCurrent;
+end;
+
+function TStringCacheDictionary<TKey>.TKeyStringEnumerator.DoGetCurrent: TPair<TKey, string>;
+var
+  Pair : TPair<TKey, NativeUInt>;
+begin
+  // Wrap the owner dictionary's internal FKeyToId enumerator, converting ID to string
+  Pair := FInternalEnum.Current;
+  Result := TPair<TKey, string>.Create(Pair.Key, FDictionary.Items[Pair.Key]);
+end;
+
+function TStringCacheDictionary<TKey>.TKeyStringEnumerator.DoMoveNext: Boolean;
+begin
+  Result := FInternalEnum.MoveNext;
 end;
 
 end.

--- a/Source/DelphiAST.Classes.pas
+++ b/Source/DelphiAST.Classes.pas
@@ -801,8 +801,16 @@ begin
 end;
 
 function TStringCacheDictionary<TKey>.ToArray: TArray<TPair<TKey, string>>;
+var
+  Value: TPair<TKey, string>;
+  I : Integer;
 begin
-  Result := ToArrayImpl(Count);
+  SetLength(Result, Count);
+  I := 0;
+  for Value in Self do begin
+    Result[I] := Value;
+    Inc(I);
+  end;
 end;
 
 function TStringCacheDictionary<TKey>.DoGetEnumerator: TEnumerator<TPair<TKey, string>>;

--- a/Source/DelphiAST.Classes.pas
+++ b/Source/DelphiAST.Classes.pas
@@ -659,20 +659,17 @@ var
 begin
   Result := 0;
   Item := TStringRec.Create(Value);
-  try
-    if FStringToId.TryGetValue(Item, Result) then begin
-      // Already exists. Increment the usage count of the existing one, and return
-      FIdToString[Result].IncUsageCount;
-      Exit; // item will be freed in finally
-    end;
 
-    // Item does not yet exist
-    Result := FIdToString.Add(Item);
-    FStringToId.Add(Item, Result);
-    Item := nil; // Do not free in finally, newly added
-  finally
-    Item.Free;
+  if FStringToId.TryGetValue(Item, Result) then begin
+    // Already exists. Increment the usage count of the existing one, and return
+    FIdToString[Result].IncUsageCount;
+    Item.Free; // Already exists, Item was search key only
+    Exit;
   end;
+
+  // Item does not yet exist
+  Result := FIdToString.Add(Item);
+  FStringToId.Add(Item, Result);
 end;
 
 function TStringCache.AddAndGet(const P : PChar; const Length : Integer) : string;

--- a/Source/DelphiAST.Classes.pas
+++ b/Source/DelphiAST.Classes.pas
@@ -172,7 +172,7 @@ type
 implementation
 
 uses
-  SysUtils, System.Types;
+  SysUtils, Types;
 
 type
   TOperatorKind = (okUnary, okBinary);

--- a/Source/DelphiAST.Classes.pas
+++ b/Source/DelphiAST.Classes.pas
@@ -16,7 +16,7 @@ type
     function GetHasChildren: Boolean;
     function GetHasAttributes: Boolean;
   protected
-    FAttributes: TDictionary<string, string>;
+    FAttributes: TDictionary<TAttributeName, string>;
     FChildNodes: TObjectList<TSyntaxNode>;
     FTyp: TSyntaxNodeType;
     FParentNode: TSyntaxNode;
@@ -26,9 +26,9 @@ type
 
     function Clone: TSyntaxNode; virtual;
 
-    function GetAttribute(const Key: string): string;
-    function HasAttribute(const Key: string): boolean;
-    procedure SetAttribute(const Key: string; Value: string);
+    function GetAttribute(const Key: TAttributeName): string;
+    function HasAttribute(const Key: TAttributeName): boolean;
+    procedure SetAttribute(const Key: TAttributeName; Value: string);
 
     function AddChild(Node: TSyntaxNode): TSyntaxNode; overload;
     function AddChild(Typ: TSyntaxNodeType): TSyntaxNode; overload;
@@ -36,7 +36,7 @@ type
 
     function FindNode(Typ: TSyntaxNodeType): TSyntaxNode;
 
-    property Attributes: TDictionary<string, string> read FAttributes;
+    property Attributes: TDictionary<TAttributeName, string> read FAttributes;
     property ChildNodes: TObjectList<TSyntaxNode> read FChildNodes;
     property HasAttributes: Boolean read GetHasAttributes;
     property HasChildren: Boolean read GetHasChildren;
@@ -366,7 +366,7 @@ end;
 
 { TSyntaxNode }
 
-procedure TSyntaxNode.SetAttribute(const Key: string; Value: string);
+procedure TSyntaxNode.SetAttribute(const Key: TAttributeName; Value: string);
 begin
   FAttributes.AddOrSetValue(Key, Value);
 end;
@@ -389,7 +389,7 @@ end;
 function TSyntaxNode.Clone: TSyntaxNode;
 var
   ChildNode: TSyntaxNode;
-  Attr: TPair<string, string>;
+  Attr: TPair<TAttributeName, string>;
 begin
   Result := TSyntaxNodeClass(Self.ClassType).Create(FTyp);
 
@@ -407,7 +407,7 @@ constructor TSyntaxNode.Create(Typ: TSyntaxNodeType);
 begin
   inherited Create;
   FTyp := Typ;
-  FAttributes := TDictionary<string, string>.Create;
+  FAttributes := TDictionary<TAttributeName, string>.Create;
   FChildNodes := TObjectList<TSyntaxNode>.Create(True);
   FParentNode := nil;
 end;
@@ -437,7 +437,7 @@ begin
     end;
 end;
 
-function TSyntaxNode.GetAttribute(const Key: string): string;
+function TSyntaxNode.GetAttribute(const Key: TAttributeName): string;
 begin
   if not FAttributes.TryGetValue(Key, Result) then
     Result := '';
@@ -453,7 +453,7 @@ begin
   Result := FChildNodes.Count > 0;
 end;
 
-function TSyntaxNode.HasAttribute(const Key: string): boolean;
+function TSyntaxNode.HasAttribute(const Key: TAttributeName): boolean;
 begin
   result := FAttributes.ContainsKey(key);
 end;

--- a/Source/DelphiAST.Consts.pas
+++ b/Source/DelphiAST.Consts.pas
@@ -136,7 +136,11 @@ type
     anName,
     anVisibility,
     anCallingConvention,
-    anPath
+    anPath,
+    anMethodBinding,
+    anReintroduce,
+    anOverload,
+    anAbstract
   );
 
 const
@@ -283,7 +287,11 @@ const
     'name',
     'visibility',
     'callingconvention',
-    'path'
+    'path',
+    'methodbinding',
+    'reintroduce',
+    'overload',
+    'abstract'
   );
 begin
   Exit(AttributeNameStrings[AttributeName]);

--- a/Source/DelphiAST.Consts.pas
+++ b/Source/DelphiAST.Consts.pas
@@ -128,6 +128,17 @@ type
     ntWrite
   );
 
+  TAttributeName = (
+    anType,
+    anClass,
+    anForwarded,
+    anKind,
+    anName,
+    anVisibility,
+    anCallingConvention,
+    anPath
+  );
+
 const
   SyntaxNodeNames: array [TSyntaxNodeType] of string = (
     'unknown',
@@ -254,15 +265,28 @@ const
     'write'
   );
 
-
 const
-  sCALLINGCONVENTION = 'callingconvention';
   sENUM              = 'enum';
-  sNAME              = 'name';
-  sPATH              = 'path';
   sSUBRANGE          = 'subrange';
-  sTYPE              = 'type';
+
+  function AttributeNameToStr(const AttributeName : TAttributeName) : string;
 
 implementation
+
+function AttributeNameToStr(const AttributeName : TAttributeName) : string;
+const
+  AttributeNameStrings : array[TAttributeName] of string = (
+    'type',
+    'class',
+    'forwarded',
+    'kind',
+    'name',
+    'visibility',
+    'callingconvention',
+    'path'
+  );
+begin
+  Exit(AttributeNameStrings[AttributeName]);
+end;
 
 end.

--- a/Source/DelphiAST.Writer.pas
+++ b/Source/DelphiAST.Writer.pas
@@ -64,7 +64,7 @@ class procedure TSyntaxTreeWriter.NodeToXML(const Builder: TStringBuilder;
   var
     HasChildren: Boolean;
     NewIndent: string;
-    Attr: TPair<string, string>;
+    Attr: TPair<TAttributeName, string>;
     ChildNode: TSyntaxNode;
   begin
     HasChildren := Node.HasChildren;
@@ -91,7 +91,7 @@ class procedure TSyntaxTreeWriter.NodeToXML(const Builder: TStringBuilder;
       Builder.Append(' value="' + TValuedSyntaxNode(Node).Value + '"');
 
     for Attr in Node.Attributes do
-      Builder.Append(' ' + LowerCase(Attr.Key) + '="' + XMLEncode(Attr.Value) + '"');
+      Builder.Append(' ' + AttributeNameToStr(Attr.Key) + '="' + XMLEncode(Attr.Value) + '"');
     if HasChildren then
       Builder.Append('>')
     else

--- a/Source/DelphiAST.pas
+++ b/Source/DelphiAST.pas
@@ -886,8 +886,21 @@ end;
 
 procedure TPasSyntaxTreeBuilder.DirectiveBinding;
 begin
-  assert(false);
-  //!!!FStack.Peek.SetAttribute(Lexer.Token, 'true');
+  // Method bindings:
+  if SameText(Lexer.Token, 'override') or SameText(Lexer.Token, 'virtual')
+    or SameText(Lexer.Token, 'dynamic')
+  then
+    FStack.Peek.SetAttribute(anMethodBinding, Lexer.Token)
+  // Other directives
+  else if SameText(Lexer.Token, 'reintroduce') then
+    FStack.Peek.SetAttribute(anReintroduce, 'true')
+  else if SameText(Lexer.Token, 'overload') then
+    FStack.Peek.SetAttribute(anOverload, 'true')
+  else if SameText(Lexer.Token, 'abstract') then
+    FStack.Peek.SetAttribute(anAbstract, 'true')
+  else
+    assert(false); // Unexpected directive
+
   inherited;
 end;
 

--- a/Source/DelphiAST.pas
+++ b/Source/DelphiAST.pas
@@ -236,8 +236,7 @@ type
 
     function Run(SourceStream: TStream): TSyntaxNode; reintroduce; overload; virtual;
     class function Run(const FileName: string;
-      InterfaceOnly: Boolean = False; IncludeHandler: IIncludeHandler = nil;
-      ClearStringCacheOnFree : Boolean = False): TSyntaxNode; reintroduce; overload; static;
+      InterfaceOnly: Boolean = False; IncludeHandler: IIncludeHandler = nil): TSyntaxNode; reintroduce; overload; static;
 
     property ClearStringCacheOnFree : Boolean read FClearStringCacheOnFree write FClearStringCacheOnFree;
   end;
@@ -1700,8 +1699,7 @@ begin
 end;
 
 class function TPasSyntaxTreeBuilder.Run(const FileName: string;
-  InterfaceOnly: Boolean; IncludeHandler: IIncludeHandler;
-  ClearStringCacheOnFree : Boolean): TSyntaxNode;
+  InterfaceOnly: Boolean; IncludeHandler: IIncludeHandler): TSyntaxNode;
 var
   Stream: TStringStream;
   Builder: TPasSyntaxTreeBuilder;
@@ -1711,7 +1709,7 @@ begin
     Stream.LoadFromFile(FileName);
     Builder := TPasSyntaxTreeBuilder.Create;
     Builder.InterfaceOnly := InterfaceOnly;
-    Builder.ClearStringCacheOnFree := ClearStringCacheOnFree;
+    Builder.ClearStringCacheOnFree := False;
     try
       Builder.InitDefinesDefinedByCompiler;
       Builder.IncludeHandler := IncludeHandler;

--- a/Source/DelphiAST.pas
+++ b/Source/DelphiAST.pas
@@ -362,7 +362,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.AsmStatement;
 begin
-  FStack.PushCompoundSyntaxNode(ntStatements).SetAttribute('type', 'asm');
+  FStack.PushCompoundSyntaxNode(ntStatements).SetAttribute(anType, 'asm');
   try
     inherited;
     SetCurrentCompoundNodesEndPosition;
@@ -543,7 +543,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.ClassClass;
 begin
-  FStack.Peek.SetAttribute('class', 'true');
+  FStack.Peek.SetAttribute(anClass, 'true');
   inherited;
 end;
 
@@ -589,13 +589,13 @@ end;
 
 procedure TPasSyntaxTreeBuilder.ClassForward;
 begin
-  FStack.Peek.SetAttribute('forwarded', 'true');
+  FStack.Peek.SetAttribute(anForwarded, 'true');
   inherited ClassForward;
 end;
 
 procedure TPasSyntaxTreeBuilder.ClassFunctionHeading;
 begin
-  FStack.Peek.SetAttribute('kind', 'function');
+  FStack.Peek.SetAttribute(anKind, 'function');
   inherited;
 end;
 
@@ -611,7 +611,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.ClassMethod;
 begin
-  FStack.Peek.SetAttribute('class', 'true');
+  FStack.Peek.SetAttribute(anClass, 'true');
   inherited;
 end;
 
@@ -628,7 +628,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.ClassProcedureHeading;
 begin
-  FStack.Peek.SetAttribute('kind', 'procedure');
+  FStack.Peek.SetAttribute(anKind, 'procedure');
   inherited;
 end;
 
@@ -644,7 +644,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.ClassReferenceType;
 begin
-  FStack.Push(ntType).SetAttribute(sTYPE, 'classof');
+  FStack.Push(ntType).SetAttribute(anType, 'classof');
   try
     inherited;
   finally
@@ -658,7 +658,7 @@ var
   i: Integer;
   extracted: Boolean;
 begin
-  FStack.Push(ntType).SetAttribute(sTYPE, 'class');
+  FStack.Push(ntType).SetAttribute(anType, 'class');
   try
     inherited;
   finally
@@ -669,7 +669,7 @@ begin
     begin
       child := classDef.ChildNodes[i];
       extracted := false;
-      if child.HasAttribute('visibility') then
+      if child.HasAttribute(anVisibility) then
         vis := child
       else if assigned(vis) then
       begin
@@ -685,7 +685,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.ConstParameter;
 begin
-  FStack.Push(ntParameters).SetAttribute('kind', 'const');
+  FStack.Push(ntParameters).SetAttribute(anKind, 'const');
   try
     inherited;
   finally
@@ -695,8 +695,8 @@ end;
 
 procedure TPasSyntaxTreeBuilder.ConstructorName;
 begin
-  FStack.Peek.SetAttribute('kind', 'constructor');
-  FStack.Peek.SetAttribute('name', Lexer.Token);
+  FStack.Peek.SetAttribute(anKind, 'constructor');
+  FStack.Peek.SetAttribute(anName, Lexer.Token);
   inherited;
 end;
 
@@ -879,20 +879,21 @@ end;
 
 procedure TPasSyntaxTreeBuilder.DestructorName;
 begin
-  FStack.Peek.SetAttribute('kind', 'destructor');
-  FStack.Peek.SetAttribute('name', Lexer.Token);
+  FStack.Peek.SetAttribute(anKind, 'destructor');
+  FStack.Peek.SetAttribute(anName, Lexer.Token);
   inherited;
 end;
 
 procedure TPasSyntaxTreeBuilder.DirectiveBinding;
 begin
-  FStack.Peek.SetAttribute(Lexer.Token, 'true');
+  assert(false);
+  //!!!FStack.Peek.SetAttribute(Lexer.Token, 'true');
   inherited;
 end;
 
 procedure TPasSyntaxTreeBuilder.DirectiveCalling;
 begin
-  FStack.Peek.SetAttribute(sCALLINGCONVENTION, Lexer.Token);
+  FStack.Peek.SetAttribute(anCallingConvention, Lexer.Token);
   inherited;
 end;
 
@@ -924,7 +925,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.EnumeratedType;
 begin
-  FStack.Push(ntType).SetAttribute(sNAME, sENUM);
+  FStack.Push(ntType).SetAttribute(anName, sENUM);
   try
     inherited;
   finally
@@ -996,7 +997,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.ExportsElement;
 begin
-  FStack.Push(ntElement).SetAttribute('name', Lexer.Token);
+  FStack.Push(ntElement).SetAttribute(anName, Lexer.Token);
   try
     inherited;
   finally
@@ -1080,7 +1081,7 @@ begin
     for ParamList in Params.ChildNodes do
     begin
       TypeInfo := ParamList.FindNode(ntType);
-      ParamKind := ParamList.GetAttribute('kind');
+      ParamKind := ParamList.GetAttribute(anKind);
       ParamExpr := ParamList.FindNode(ntExpression);
 
       for Param in ParamList.ChildNodes do
@@ -1090,7 +1091,7 @@ begin
 
         FStack.Push(ntParameter);
         if ParamKind <> '' then
-          FStack.Peek.SetAttribute('kind', ParamKind);
+          FStack.Peek.SetAttribute(anKind, ParamKind);
 
         FStack.Peek.Col  := Param.Col;
         FStack.Peek.Line := Param.Line;
@@ -1163,7 +1164,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.FunctionHeading;
 begin
-  FStack.Peek.SetAttribute('kind', 'function');
+  FStack.Peek.SetAttribute(anKind, 'function');
   inherited;
 end;
 
@@ -1195,7 +1196,7 @@ begin
           begin
             if TypeParams <> '' then
               TypeParams := TypeParams + ',';
-            TypeParams := TypeParams + TypeNode.GetAttribute(sNAME);
+            TypeParams := TypeParams + TypeNode.GetAttribute(anName);
           end;
         end;
 
@@ -1209,7 +1210,7 @@ begin
     end;
   finally
     FStack.Pop;
-    FStack.Peek.SetAttribute(sNAME, FullName);
+    FStack.Peek.SetAttribute(anName, FullName);
     FStack.Peek.DeleteChild(nameNode);
   end;
 end;
@@ -1226,7 +1227,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.Identifier;
 begin
-  FStack.AddChild(ntIdentifier).SetAttribute(sNAME, Lexer.Token);
+  FStack.AddChild(ntIdentifier).SetAttribute(anName, Lexer.Token);
   inherited;
 end;
 
@@ -1304,7 +1305,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.InterfaceForward;
 begin
-  FStack.Peek.SetAttribute('forwarded', 'true');
+  FStack.Peek.SetAttribute(anForwarded, 'true');
   inherited InterfaceForward;
 end;
 
@@ -1331,7 +1332,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.InterfaceType;
 begin
-  FStack.Push(ntType).SetAttribute(sTYPE, 'interface');
+  FStack.Push(ntType).SetAttribute(anType, 'interface');
   try
     inherited;
   finally
@@ -1359,13 +1360,13 @@ begin
 
     if Assigned(NameNode) then
     begin
-      FStack.Peek.SetAttribute(sNAME, NameNode.GetAttribute(sNAME));
+      FStack.Peek.SetAttribute(anName, NameNode.GetAttribute(anName));
       FStack.Peek.DeleteChild(NameNode);
     end;
 
     if PathNode is TValuedSyntaxNode then
     begin
-      FStack.Peek.SetAttribute(sPATH, TValuedSyntaxNode(PathNode).Value);
+      FStack.Peek.SetAttribute(anPath, TValuedSyntaxNode(PathNode).Value);
       FStack.Peek.DeleteChild(PathNode);
     end;
   finally
@@ -1386,7 +1387,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.MethodKind;
 begin
-  FStack.Peek.SetAttribute('kind', LowerCase(Lexer.Token));
+  FStack.Peek.SetAttribute(anKind, LowerCase(Lexer.Token));
   inherited;
 end;
 
@@ -1426,7 +1427,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.NilToken;
 begin
-  FStack.AddChild(ntLiteral).SetAttribute(sTYPE, 'nil');
+  FStack.AddChild(ntLiteral).SetAttribute(anType, 'nil');
   inherited;
 end;
 
@@ -1441,7 +1442,7 @@ var
   Node: TSyntaxNode;
 begin
   Node := FStack.AddValuedChild(ntLiteral, Lexer.Token);
-  Node.SetAttribute(sTYPE, 'numeric');
+  Node.SetAttribute(anType, 'numeric');
   inherited;
 end;
 
@@ -1460,7 +1461,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.OutParameter;
 begin
-  FStack.Push(ntParameters).SetAttribute('kind', 'out');
+  FStack.Push(ntParameters).SetAttribute(anKind, 'out');
   try
     inherited;
   finally
@@ -1492,7 +1493,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.PointerType;
 begin
-  FStack.Push(ntType).SetAttribute(sTYPE, 'pointer');
+  FStack.Push(ntType).SetAttribute(anType, 'pointer');
   try
     inherited;
   finally
@@ -1512,7 +1513,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.ProceduralType;
 begin
-  FStack.Push(ntType).SetAttribute(sNAME, Lexer.Token);
+  FStack.Push(ntType).SetAttribute(anName, Lexer.Token);
   try
     inherited;
   finally
@@ -1533,19 +1534,19 @@ end;
 
 procedure TPasSyntaxTreeBuilder.ProcedureHeading;
 begin
-  FStack.Peek.SetAttribute('kind', 'procedure');
+  FStack.Peek.SetAttribute(anKind, 'procedure');
   inherited;
 end;
 
 procedure TPasSyntaxTreeBuilder.ProcedureProcedureName;
 begin
-  FStack.Peek.SetAttribute(sNAME, Lexer.Token);
+  FStack.Peek.SetAttribute(anName, Lexer.Token);
   inherited;
 end;
 
 procedure TPasSyntaxTreeBuilder.PropertyName;
 begin
-  FStack.Peek.SetAttribute('name', Lexer.Token);
+  FStack.Peek.SetAttribute(anName, Lexer.Token);
   inherited PropertyName;
 end;
 
@@ -1575,7 +1576,7 @@ var
 begin
   Node := FStack.PushValuedNode(ntField, Lexer.Token);
   try
-    Node.SetAttribute(sTYPE, 'name');
+    Node.SetAttribute(anType, 'name');
     inherited;
   finally
     FStack.Pop;
@@ -1643,7 +1644,7 @@ begin
       FStack.Pop;
     end;
 
-    FStack.AddChild(ntPackage).SetAttribute(sNAME, NodeListToString(NamesNode));
+    FStack.AddChild(ntPackage).SetAttribute(anName, NodeListToString(NamesNode));
   finally
     NamesNode.Free;
   end;
@@ -1651,7 +1652,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.RequiresIdentifierId;
 begin
-  FStack.AddChild(ntUnknown, False).SetAttribute(sNAME, Lexer.Token);
+  FStack.AddChild(ntUnknown, False).SetAttribute(anName, Lexer.Token);
   inherited;
 end;
 
@@ -1732,7 +1733,7 @@ begin
   begin
     if Result <> '' then
       Result := Result + '.';
-    Result := Result + NamePartNode.Attributes[sNAME];
+    Result := Result + NamePartNode.Attributes[anName];
   end;
 end;
 
@@ -1844,7 +1845,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.SimpleType;
 begin
-  FStack.Push(ntType).SetAttribute(sNAME, Lexer.Token);
+  FStack.Push(ntType).SetAttribute(anName, Lexer.Token);
   try
     inherited;
   finally
@@ -1896,7 +1897,7 @@ begin
   end;
 
   Node := FStack.AddValuedChild(ntLiteral, Str);
-  Node.SetAttribute(sTYPE, 'string');
+  Node.SetAttribute(anType, 'string');
 end;
 
 procedure TPasSyntaxTreeBuilder.StringConstSimple;
@@ -1908,7 +1909,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.StringType;
 begin
-  FStack.Push(ntType).SetAttribute(sNAME, Lexer.Token);
+  FStack.Push(ntType).SetAttribute(anName, Lexer.Token);
   try
     inherited;
   finally
@@ -1918,7 +1919,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.StructuredType;
 begin
-  FStack.Push(ntType).SetAttribute(sTYPE, Lexer.Token);
+  FStack.Push(ntType).SetAttribute(anType, Lexer.Token);
   try
     inherited;
   finally
@@ -1928,7 +1929,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.SubrangeType;
 begin
-  FStack.Push(ntType).SetAttribute(sNAME, sSUBRANGE);
+  FStack.Push(ntType).SetAttribute(anName, sSUBRANGE);
   try
     inherited;
   finally
@@ -1968,7 +1969,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.TypeDeclaration;
 begin
-  FStack.PushCompoundSyntaxNode(ntTypeDecl).SetAttribute(sNAME, Lexer.Token);
+  FStack.PushCompoundSyntaxNode(ntTypeDecl).SetAttribute(anName, Lexer.Token);
   try
     inherited;
     SetCurrentCompoundNodesEndPosition;
@@ -1991,7 +1992,7 @@ begin
     InnerTypeNode := TypeNode.FindNode(ntType);    
     if Assigned(InnerTypeNode) then
     begin
-      InnerTypeName := InnerTypeNode.GetAttribute(sNAME);
+      InnerTypeName := InnerTypeNode.GetAttribute(anName);
       for SubNode in InnerTypeNode.ChildNodes do 
         TypeNode.AddChild(SubNode.Clone);
         
@@ -2007,7 +2008,7 @@ begin
         if TypeName <> '' then
           TypeName := '.' + TypeName;
           
-        TypeName := SubNode.GetAttribute(sNAME) + TypeName;
+        TypeName := SubNode.GetAttribute(anName) + TypeName;
         TypeNode.DeleteChild(SubNode);
       end;       
     end;
@@ -2016,7 +2017,7 @@ begin
       TypeName := '.' + TypeName;   
     TypeName := InnerTypeName + TypeName;  
       
-    TypeNode.SetAttribute(sNAME, TypeName); 
+    TypeNode.SetAttribute(anName, TypeName);
    
   finally
     FStack.Pop;
@@ -2089,7 +2090,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.TypeSimple;
 begin
-  FStack.Push(ntType).SetAttribute(sNAME, Lexer.Token); 
+  FStack.Push(ntType).SetAttribute(anName, Lexer.Token);
   try
     inherited;
   finally
@@ -2112,7 +2113,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.UnitId;
 begin
-  FStack.AddChild(ntUnknown, False).SetAttribute(sNAME, Lexer.Token);
+  FStack.AddChild(ntUnknown, False).SetAttribute(anName, Lexer.Token);
   inherited;
 end;
 
@@ -2129,7 +2130,7 @@ begin
       FStack.Pop;
     end;
 
-    FStack.Peek.SetAttribute(sNAME, NodeListToString(NamesNode));
+    FStack.Peek.SetAttribute(anName, NodeListToString(NamesNode));
   finally
     NamesNode.Free;
   end;
@@ -2152,7 +2153,7 @@ begin
     end;
 
     UnitNode := FStack.AddChild(ntUnit);
-    UnitNode.SetAttribute(sNAME, NodeListToString(NamesNode));
+    UnitNode.SetAttribute(anName, NodeListToString(NamesNode));
     UnitNode.Col  := Position.X;
     UnitNode.Line := Position.Y;
   finally
@@ -2189,7 +2190,7 @@ end;
 
 procedure TPasSyntaxTreeBuilder.VarParameter;
 begin
-  FStack.Push(ntParameters).SetAttribute('kind', 'var');
+  FStack.Push(ntParameters).SetAttribute(anKind, 'var');
   try
     inherited;
   finally
@@ -2248,7 +2249,7 @@ procedure TPasSyntaxTreeBuilder.VisibilityPrivate;
 begin
   FStack.Push(ntPrivate);
   try
-    FStack.Peek.SetAttribute('visibility', 'true');
+    FStack.Peek.SetAttribute(anVisibility, 'true');
     inherited;
   finally
     FStack.Pop;
@@ -2259,7 +2260,7 @@ procedure TPasSyntaxTreeBuilder.VisibilityProtected;
 begin
   FStack.Push(ntProtected);
   try
-    FStack.Peek.SetAttribute('visibility', 'true');
+    FStack.Peek.SetAttribute(anVisibility, 'true');
     inherited;
   finally
     FStack.Pop;
@@ -2270,7 +2271,7 @@ procedure TPasSyntaxTreeBuilder.VisibilityPublic;
 begin
   FStack.Push(ntPublic);
   try
-    FStack.Peek.SetAttribute('visibility', 'true');
+    FStack.Peek.SetAttribute(anVisibility, 'true');
     inherited;
   finally
     FStack.Pop;
@@ -2281,7 +2282,7 @@ procedure TPasSyntaxTreeBuilder.VisibilityPublished;
 begin
   FStack.Push(ntPublished);
   try
-    FStack.Peek.SetAttribute('visibility', 'true');
+    FStack.Peek.SetAttribute(anVisibility, 'true');
     inherited;
   finally
     FStack.Pop;

--- a/Source/DelphiAST.pas
+++ b/Source/DelphiAST.pas
@@ -59,8 +59,6 @@ type
   private type
     TExpressionMethod = procedure of object;
   private
-    FClearStringCacheOnFree : Boolean;
-
     procedure BuildExpressionTree(ExpressionMethod: TExpressionMethod);
     procedure ParserMessage(Sender: TObject; const Typ: TMessageEventType; const Msg: string; X, Y: Integer);
     function NodeListToString(NamesNode: TSyntaxNode): string;
@@ -237,8 +235,6 @@ type
     function Run(SourceStream: TStream): TSyntaxNode; reintroduce; overload; virtual;
     class function Run(const FileName: string;
       InterfaceOnly: Boolean = False; IncludeHandler: IIncludeHandler = nil): TSyntaxNode; reintroduce; overload; static;
-
-    property ClearStringCacheOnFree : Boolean read FClearStringCacheOnFree write FClearStringCacheOnFree;
   end;
 
 implementation
@@ -863,7 +859,6 @@ constructor TPasSyntaxTreeBuilder.Create;
 begin
   inherited;
   FStack := TNodeStack.Create(Self);
-  FClearStringCacheOnFree := true;
 end;
 
 procedure TPasSyntaxTreeBuilder.Designator;
@@ -879,8 +874,6 @@ end;
 destructor TPasSyntaxTreeBuilder.Destroy;
 begin
   FStack.Free;
-  if FClearStringCacheOnFree then
-    TStringCache.Instance.Clear;
   inherited;
 end;
 
@@ -1709,7 +1702,6 @@ begin
     Stream.LoadFromFile(FileName);
     Builder := TPasSyntaxTreeBuilder.Create;
     Builder.InterfaceOnly := InterfaceOnly;
-    Builder.ClearStringCacheOnFree := False;
     try
       Builder.InitDefinesDefinedByCompiler;
       Builder.IncludeHandler := IncludeHandler;

--- a/Source/SimpleParser/SimpleParser.Lexer.pas
+++ b/Source/SimpleParser/SimpleParser.Lexer.pas
@@ -393,7 +393,7 @@ type
 implementation
 
 uses
-  StrUtils;
+  StrUtils, DelphiAST.Classes;
 
 type
   TmwPasLexExpressionEvaluation = (leeNone, leeAnd, leeOr);
@@ -2164,7 +2164,7 @@ end;
 
 function TmwBasePasLex.GetToken: string;
 begin
-  SetString(Result, (FOrigin + FTokenPos), GetTokenLen);
+  Result := TStringCache.Instance.AddAndGet(FOrigin + FTokenPos, GetTokenLen);
 end;
 
 function TmwBasePasLex.GetTokenLen: Integer;

--- a/Source/SimpleParser/SimpleParser.Lexer.pas
+++ b/Source/SimpleParser/SimpleParser.Lexer.pas
@@ -1315,10 +1315,14 @@ begin
   FTopDefineRec := nil;
   FUseSharedOrigin := false;
   ClearDefines;
+
+  TStringCache.Instance.IncRef; // Uses the cache for GetToken
 end;
 
 destructor TmwBasePasLex.Destroy;
 begin
+  TStringCache.Instance.DecRef;
+
   ClearDefines; //If we don't do this, we get a memory leak
   FDefines.Free;
   if not FUseSharedOrigin then


### PR DESCRIPTION
This commit is intended to help reduce memory fragementation when DelphiAST is run many times (hundreds or thousands.)  It reduces the number of unique strings stored in memory, and later freed.

There is a new string cache class in DelphiAST.Classes, which stores a copy of each string, and assigns each string an ID.  You can perform an ID -> string lookup, and string-> ID lookup.  There is a single global instance of this, and it may be possible to use it in other places in the code later.  Currently, it is cleared by default when TPasSyntaxTreeBuilder is freed (eg after a Run call if you follow the demo code) but there is a flag to not do this, which makes it persistent, which is very useful for code that calls Run or parses many times.

There is then a new class that implements the Attributes dictionary.  Internally, this stores attribute name -> string ID, and adding attributes uses the string cache so stores the ID of the string, not the string itself.  It pulls in many methods from TDictionary<> and code using Attributes should not require any changes.  It's still enumerable etc, and gives the same external interface to code.  Where possible, it uses classes inheriting from the RTL TEnumerable (etc) classes, just like the RTL TDictionary, in order to reduce any possible incompatibilities with existing code.

This means that to outside code there are no visible changes, but internally attributes use the string cache and there is only one copy of each unique string stored.

Parsing System.Classes.pas (XE7) this saves about 100KB of memory, and over 112000 individual strings.  That's a lot!  Removing the need for that many strings in memory each time it parses should go a long way towards helping reduce memory fragmentation.