### PR TITLE
Fixed buffer overflow on including more than 2 MB into a file

### DIFF
--- a/Source/SimpleParser/SimpleParser.Lexer.Types.pas
+++ b/Source/SimpleParser/SimpleParser.Lexer.Types.pas
@@ -271,6 +271,7 @@ type
     TokenID: TptTokenKind;
   end;
 
+  EIncludeError = class(Exception);
   IIncludeHandler = interface
     ['{C5F20740-41D2-43E9-8321-7FE5E3AA83B6}']
     function GetIncludeFileContent(const FileName: string): string;

--- a/Source/SimpleParser/SimpleParser.Lexer.pas
+++ b/Source/SimpleParser/SimpleParser.Lexer.pas
@@ -2421,7 +2421,7 @@ begin
     end
     else
     begin    
-      StrPCopy(@FOrigin[Run], Content);//sdfsdf
+      StrPCopy(@FOrigin[Run], Content);
       FOrigin[Run + Length(Content)] := #0;
     end;
 

--- a/Source/SimpleParser/SimpleParser.Lexer.pas
+++ b/Source/SimpleParser/SimpleParser.Lexer.pas
@@ -2394,13 +2394,13 @@ end;
 
 procedure TmwBasePasLex.IncludeFile;
 var
-  IndludeFileName, IncludeDirective, Content, Origin, BehindIncludedContent: string;
+  IncludeFileName, IncludeDirective, Content, Origin, BehindIncludedContent: string;
   pBehindIncludedContent: PChar;
   TempBufferSize: integer;
 begin
   IncludeDirective := Token;
-  IndludeFileName := GetIncludeFileNameFromToken(IncludeDirective);
-  Content := FIncludeHandler.GetIncludeFileContent(IndludeFileName) + #13#10;
+  IncludeFileName := GetIncludeFileNameFromToken(IncludeDirective);
+  Content := FIncludeHandler.GetIncludeFileContent(IncludeFileName) + #13#10;
 
   Origin := FOrigin;
   TempBufferSize := (Length(Origin) + INCLUDE_BUFFER_SIZE) * SizeOf(Char);
@@ -2413,8 +2413,17 @@ begin
     UpdateIncludedLineCount(Content);
 
     Content := Content + BehindIncludedContent;
-    StrPCopy(@FOrigin[Run], Content);
-    FOrigin[Run + Length(Content)] := #0;
+    
+    if (Run + Length(Content)) * SizeOf(Char) > BufferSize then
+    begin
+      Run := Run + Length(IncludeDirective);
+      raise EIncludeError.Create('Content size of include file ' + IncludeFileName + ' exceeds buffer limit.');
+    end
+    else
+    begin    
+      StrPCopy(@FOrigin[Run], Content);//sdfsdf
+      FOrigin[Run + Length(Content)] := #0;
+    end;
 
     Next;
   finally


### PR DESCRIPTION
The current implementation for including files can cause a buffer overflow when a file includes more than 2 MB. That error is fixed by this pull request.