### PR TITLE
Performance improvement

### DIFF
--- a/Source/DelphiAST.pas
+++ b/Source/DelphiAST.pas
@@ -1812,7 +1812,7 @@ begin
   begin
     if Result <> '' then
       Result := Result + '.';
-    Result := Result + NamePartNode.Attributes[anName];
+    Result := Result + NamePartNode.GetAttribute(anName);
   end;
 end;
 

--- a/Source/DelphiAST.pas
+++ b/Source/DelphiAST.pas
@@ -668,7 +668,7 @@ begin
     classDef := FStack.Pop;
     vis := nil;
     i := 0;
-    while i < classDef.ChildNodes.Count do
+    while i < Length(classDef.ChildNodes) do
     begin
       child := classDef.ChildNodes[i];
       extracted := false;
@@ -676,8 +676,8 @@ begin
         vis := child
       else if assigned(vis) then
       begin
-        classDef.ChildNodes.Extract(child);
-        vis.ChildNodes.Add(child);
+        classDef.ExtractChild(child);
+        vis.AddChild(child);
         extracted := true;
       end;
       if not extracted then
@@ -1871,7 +1871,7 @@ begin
         NodeList := TList<TSyntaxNode>.Create;
         try
           AssignIdx := -1;
-          for I := 0 to RawStatement.ChildNodes.Count - 1 do
+          for I := 0 to Length(RawStatement.ChildNodes) - 1 do
           begin
             if RawStatement.ChildNodes[I].Typ = ntAssign then
             begin
@@ -1892,7 +1892,7 @@ begin
 
           NodeList.Clear;
 
-          for I := AssignIdx + 1 to RawStatement.ChildNodes.Count - 1 do
+          for I := AssignIdx + 1 to Length(RawStatement.ChildNodes) - 1 do
             NodeList.Add(RawStatement.ChildNodes[I]);
 
           if NodeList.Count = 0 then
@@ -2086,7 +2086,7 @@ begin
     end;       
     
     TypeName := '';
-    for i := TypeNode.ChildNodes.Count - 1 downto 0 do
+    for i := Length(TypeNode.ChildNodes) - 1 downto 0 do
     begin
       SubNode := TypeNode.ChildNodes[i];
       if SubNode.Typ = ntType then


### PR DESCRIPTION
I had a look at the memory comsumption of DelphiAST.
An **empty** instance of **`TSyntaxNode`** (no child nodes, no attributes, empty file name) reserves **148 byte**. In huge files we can have more than 100k instances of that class. So the memory consumption matters.

I've seen **60 byte** are reserved for **`FChildNode: TObjectList<TSyntaxNode>`** and **52 byte** are used for **`FAttributes: TDictionary<TAttributeName, string>`**

I reimplemented these members as arrays and had a look at the performance. I tested with a slightly modified version of JEDI's `mscorlib_tlb.pas` (~1.5 MB). 

**The results:**

Test|Empty node size|Size of AST for `mscorlib_tlb`|Duration for building the AST
----|---------------|------------------------------|-----------------------------
ChildNodes as `TObjectList` and Attributes as `TDictionary`|148 byte|14,647,240 byte|187 ms
ChildNodes as `array`|88 byte (-40.54%)|10,825,700 byte (-26.09%)|156 ms (-16.58%)
ChildNodes and Attributes as array|36 byte (-75,68%)|6,572,712 byte (-55.13%)|109 ms (-41.71%)

All my integration tests still work with these changes. An internal version of OmniPascal uses this version of DelphiAST. I consider it as stable.
