### PR TITLE
Fix: TSyntaxNode.Clone didn't clone FileName property

### DIFF
--- a/Source/DelphiAST.Classes.pas
+++ b/Source/DelphiAST.Classes.pas
@@ -420,6 +420,7 @@ begin
 
   Result.Col := Self.Col;
   Result.Line := Self.Line;
+  Result.FileName := Self.FileName;
 end;
 
 constructor TSyntaxNode.Create(Typ: TSyntaxNodeType);


### PR DESCRIPTION
The FileName value was lost on cloning a `TSyntaxNode`.