### PR TITLE
TPasSyntaxTreeBuilder handles ESyntaxError properly

### DIFF
--- a/Source/DelphiAST.pas
+++ b/Source/DelphiAST.pas
@@ -1795,6 +1795,8 @@ begin
   except
     on E: EParserException do
       raise ESyntaxTreeException.Create(E.Line, E.Col, Lexer.FileName, E.Message, Result);
+    on E: ESyntaxError do 
+      raise ESyntaxTreeException.Create(E.PosXY.X, E.PosXY.Y, Lexer.FileName, E.Message, Result);      
     else
       FreeAndNil(Result);
       raise;


### PR DESCRIPTION
Exceptions of type `ESyntaxError` haven't been handled properly in `TPasSyntaxTreeBuilder`.