### PR TITLE
Added assignment check before cloning

### DIFF
--- a/Source/DelphiAST.pas
+++ b/Source/DelphiAST.pas
@@ -2320,7 +2320,8 @@ begin
           FStack.Peek.Line := Variable.Line;
 
           FStack.AddChild(Variable.Clone);
-          FStack.AddChild(TypeInfo.Clone);
+          if Assigned(TypeInfo) then
+            FStack.AddChild(TypeInfo.Clone);
 
           if Assigned(ValueInfo) then
             FStack.AddChild(ValueInfo.Clone);


### PR DESCRIPTION
When the `FOnMessage` event doesn't throw an exception when a var section contains syntax errors then `TypeInfo` can be `nil`.