### PR TITLE
Files with statements only can be parsed

### DIFF
--- a/Source/SimpleParser/SimpleParser.pas
+++ b/Source/SimpleParser/SimpleParser.pas
@@ -5310,14 +5310,7 @@ begin
         end;
       ptIdentifier:
         begin
-          Lexer.InitAhead;
-          if Lexer.AheadTokenID in [ptColon, ptEqual] then
-          begin
-            ConstantDeclaration;
-            if TokenID = ptSemiColon then Semicolon;
-          end
-          else
-            NextToken;
+          Statements;
         end;
       ptLabel:
         begin


### PR DESCRIPTION
I don't know why the parser handles `ptIdentifier` so different here. But when you parse a file that starts with statements like the following then you receive an empty tree. 

A file like this:
```pascal
MyObject.DoWhatever(5);
```

now results in a valid tree.
Was there any particular reason for handling `ptIdentifier` differently?