### PR TITLE
Added support for {..} and (*..*) comments and attaching them nodes

### DIFF
--- a/Source/DelphiAST.Classes.pas
+++ b/Source/DelphiAST.Classes.pas
@@ -19,9 +19,11 @@ type
     property Line: Integer read FLine;
     property Col: Integer read FCol;
   end;
-  
+
   TAttributeEntry = TPair<TAttributeName, string>;
   PAttributeEntry = ^TAttributeEntry;
+
+  TCommentNode = class;
 
   TSyntaxNodeClass = class of TSyntaxNode;
   TSyntaxNode = class
@@ -37,6 +39,7 @@ type
     FChildNodes: TArray<TSyntaxNode>;
     FTyp: TSyntaxNodeType;
     FParentNode: TSyntaxNode;
+    FLastPrecedingCommentNode: TCommentNode;
   public
     constructor Create(Typ: TSyntaxNodeType);
     destructor Destroy; override;
@@ -62,6 +65,11 @@ type
     property HasChildren: Boolean read GetHasChildren;
     property Typ: TSyntaxNodeType read FTyp;
     property ParentNode: TSyntaxNode read FParentNode;
+
+    { The last comment node that preceeds this node.
+      Only available after TPasSyntaxTreeBuilder.AttachCommentNodes has been
+      called. }
+    property LastPrecedingCommentNode: TCommentNode read FLastPrecedingCommentNode write FLastPrecedingCommentNode;
 
     property Col: Integer read FCol write FCol;
     property Line: Integer read FLine write FLine;
@@ -422,6 +430,7 @@ begin
   Result.Col := Self.Col;
   Result.Line := Self.Line;
   Result.FileName := Self.FileName;
+  Result.FLastPrecedingCommentNode := Self.FLastPrecedingCommentNode;
 end;
 
 constructor TSyntaxNode.Create(Typ: TSyntaxNodeType);

--- a/Source/DelphiAST.pas
+++ b/Source/DelphiAST.pas
@@ -56,6 +56,14 @@ type
     procedure CallInheritedExpression;
     procedure SetCurrentCompoundNodesEndPosition;
     procedure DoOnComment(Sender: TObject; const Text: string);
+  private
+    FCommentIndex: Integer;
+    FCommentNode: TCommentNode;
+    FCommentText: String;
+    FCommentPos: UInt32;
+    function SetActiveComment(const Index: Integer): Boolean;
+    procedure ApplyCommentNodes(const Node, PrevNode: TSyntaxNode);
+    class function GetNodePos(const Node: TSyntaxNode): UInt32; static;
   protected
     FStack: TNodeStack;
     FComments: TObjectList<TCommentNode>;
@@ -237,6 +245,11 @@ type
     class function Run(const FileName: string;
       InterfaceOnly: Boolean = False; IncludeHandler: IIncludeHandler = nil): TSyntaxNode; reintroduce; overload; static;
 
+    { Sets the LastPrecedingCommentNode property of each node to the last
+      comment that preceeds the node.
+      Root must be the node returned from Run. }
+    procedure AttachCommentNodes(const Root: TSyntaxNode);
+
     property Comments: TObjectList<TCommentNode> read FComments;
   end;
 
@@ -333,6 +346,38 @@ begin
   end;
 end;
 
+procedure TPasSyntaxTreeBuilder.ApplyCommentNodes(const Node,
+  PrevNode: TSyntaxNode);
+var
+  LastNode, Child: TSyntaxNode;
+begin
+  Assert(Assigned(Node));
+  Assert(Assigned(PrevNode));
+
+  { Use "while True" loop so that if multiple comments preceed a declaration,
+    only the last one is used. }
+  while True do
+  begin
+    if (FCommentPos > GetNodePos(PrevNode)) and (FCommentPos < GetNodePos(Node)) then
+    begin
+      Node.LastPrecedingCommentNode := FCommentNode;
+      if (not SetActiveComment(FCommentIndex + 1)) then
+        Exit;
+    end
+    else
+      Break;
+  end;
+
+  LastNode := Node;
+  for Child in Node.ChildNodes do
+  begin
+    ApplyCommentNodes(Child, LastNode);
+    if (FCommentNode = nil) then
+      Exit;
+    LastNode := Child;
+  end;
+end;
+
 procedure TPasSyntaxTreeBuilder.ArrayBounds;
 begin
   FStack.Push(ntBounds);
@@ -394,6 +439,12 @@ begin
   finally
     FStack.Pop;
   end;
+end;
+
+procedure TPasSyntaxTreeBuilder.AttachCommentNodes(const Root: TSyntaxNode);
+begin
+  if SetActiveComment(0) then
+    ApplyCommentNodes(Root, Root);
 end;
 
 procedure TPasSyntaxTreeBuilder.Attribute;
@@ -1288,6 +1339,19 @@ begin
   end;
 end;
 
+class function TPasSyntaxTreeBuilder.GetNodePos(
+  const Node: TSyntaxNode): UInt32;
+var
+  Line, Col: UInt32;
+begin
+  Assert(Assigned(Node));
+  Line := Node.Line;
+  Col := Node.Col;
+  if (Col > 255) then
+    Col := 255;
+  Result := (Line shl 24) or Col;
+end;
+
 procedure TPasSyntaxTreeBuilder.GotoStatement;
 begin
   FStack.Push(ntGoto);
@@ -1548,7 +1612,7 @@ var
 begin
   case TokenID of
     ptAnsiComment: Node := TCommentNode.Create(ntAnsiComment);
-    ptBorComment: Node := TCommentNode.Create(ntAnsiComment);
+    ptBorComment: Node := TCommentNode.Create(ntBorComment);
     ptSlashesComment: Node := TCommentNode.Create(ntSlashesComment);
   else
     raise EParserException.Create(Lexer.PosXY.Y, Lexer.PosXY.X, Lexer.FileName, 'Invalid comment type');
@@ -1867,6 +1931,20 @@ begin
       Result := Result + '.';
     Result := Result + NamePartNode.GetAttribute(anName);
   end;
+end;
+
+function TPasSyntaxTreeBuilder.SetActiveComment(const Index: Integer): Boolean;
+begin
+  Result := (Index < FComments.Count);
+  if (Result) then
+  begin
+    FCommentIndex := Index;
+    FCommentNode := FComments[Index];
+    FCommentText := FCommentNode.Text;
+    FCommentPos := GetNodePos(FCommentNode);
+  end
+  else
+    FCommentNode := nil;
 end;
 
 procedure TPasSyntaxTreeBuilder.SetConstructor;

--- a/Source/SimpleParser/SimpleParser.Lexer.pas
+++ b/Source/SimpleParser/SimpleParser.Lexer.pas
@@ -1483,6 +1483,9 @@ begin
 end;
 
 procedure TmwBasePasLex.BraceOpenProc;
+var
+  BeginRun: Integer;
+  CommentText: String;
 begin
   case FBuffer.Buf[FBuffer.Run + 1] of
     '$': FTokenID := GetDirectiveKind;
@@ -1493,10 +1496,17 @@ begin
     end;
   end;
   Inc(FBuffer.Run);
+  BeginRun := FBuffer.Run; // EvB
   while FBuffer.Buf[FBuffer.Run] <> #0 do
     case FBuffer.Buf[FBuffer.Run] of
       '}':
         begin
+          if (FTokenId = ptBorComment) and Assigned(FOnComment) then
+          begin
+            SetString(CommentText, PChar(@FBuffer.Buf[BeginRun]), FBuffer.Run - BeginRun);
+            FOnComment(Self, CommentText);
+          end;
+
           FCommentState := csNo;
           Inc(FBuffer.Run);
           Break;
@@ -1990,6 +2000,9 @@ begin
 end;
 
 procedure TmwBasePasLex.RoundOpenProc;
+var
+  CommentText: String;
+  BeginRun: Integer;
 begin
   Inc(FBuffer.Run);
   case FBuffer.Buf[FBuffer.Run] of
@@ -2001,11 +2014,18 @@ begin
         else
           FCommentState := csAnsi;
         Inc(FBuffer.Run);
+        BeginRun := FBuffer.Run; // EvB
         while FBuffer.Buf[FBuffer.Run] <> #0 do
           case FBuffer.Buf[FBuffer.Run] of
             '*':
               if FBuffer.Buf[FBuffer.Run + 1] = ')' then
               begin
+                if (FTokenId = ptAnsiComment) and Assigned(FOnComment) then
+                begin
+                  SetString(CommentText, PChar(@FBuffer.Buf[BeginRun]), FBuffer.Run - BeginRun);
+                  FOnComment(Self, CommentText);
+                end;
+
                 FCommentState := csNo;
                 Inc(FBuffer.Run, 2);
                 Break;


### PR DESCRIPTION
Currently, DelphiAST only extracts "//..." style comments. This branch adds support for "{..}" and "(*..*)" comments as well. This only required changes to SimpleParser.Lexer.pas.

In addition, I added support for attaching the last preceding comments to TSyntaxNodes, through the new TSyntaxNode.LastPrecedingCommentNode property.

Support for this is disabled by default, since not everyone may be interested in comments. To attach the comments to their nodes, I added TPasSyntaxTreeBuilder.AttachCommentNodes.

There have been discussions about where to place comment nodes in the tree. The approach I took here was not the place comments nodes in the tree, but to associate each comment with the node that succeeds it. This is the same convention that is used in the Delphi RTL/VCL/FMX source code: the documentation for a declaration is written in a comment preceding the declaration itself.

If there are more comments preceding a node, then only the last comment is attached.