### PR TITLE
implemented string interning

### DIFF
--- a/Demo/DelphiASTDemo.dpr
+++ b/Demo/DelphiASTDemo.dpr
@@ -1,8 +1,10 @@
 program DelphiASTDemo;
 
 uses
+  FastMM4,
   Forms,
-  uMainForm in 'uMainForm.pas' {MainForm};
+  uMainForm in 'uMainForm.pas' {MainForm},
+  StringUsageLogging in 'StringUsageLogging.pas';
 
 {$R *.res}
 

--- a/Demo/StringUsageLogging.pas
+++ b/Demo/StringUsageLogging.pas
@@ -1,0 +1,94 @@
+unit StringUsageLogging;
+
+interface
+
+uses
+  Generics.Collections;
+
+type
+  TStringUsage = TPair<string,Integer>;
+
+function LogStringUsage: TArray<TStringUsage>;
+procedure LogStringUsageToFile(const fileName: string);
+
+implementation
+
+uses
+  Generics.Defaults, FastMM4, Math, Classes, SysUtils;
+
+type
+  PStrRec = ^StrRec;
+  StrRec = packed record
+  {$IF defined(CPU64BITS)}
+    _Padding: Integer;
+  {$IFEND}
+    codePage: Word;
+    elemSize: Word;
+    refCnt: Integer;
+    length: Integer;
+  end;
+
+procedure Callback(APBlock: Pointer; ABlockSize: NativeInt; AUserData: Pointer);
+var
+  items: TDictionary<string,Integer>;
+  count: Integer;
+begin
+  items := TDictionary<string,Integer>(AUserData);
+  if (DetectClassInstance(APBlock) = nil)
+    and (DetectStringData(APBlock, ABlockSize) = stUnicodeString) then
+  begin
+    items.TryGetValue(string(PByte(APBlock) + SizeOf(StrRec)), count);
+    items.AddOrSetValue(string(PByte(APBlock) + SizeOf(StrRec)), count + 1);
+  end;
+end;
+
+function LogStringUsage: TArray<TStringUsage>;
+var
+  items: TDictionary<string,Integer>;
+  comparer: TComparison<TStringUsage>;
+begin
+  items := TDictionary<string,Integer>.Create;
+  try
+    WalkAllocatedBlocks(Callback, items);
+    Result := items.ToArray;
+    comparer :=
+      function(const left, right: TStringUsage): Integer
+      begin
+        Result := -CompareValue(left.Value, right.Value);
+      end;
+    TArray.Sort<TStringUsage>(Result, IComparer<TStringUsage>(PPointer(@comparer)^));
+  finally
+    items.Free;
+  end;
+end;
+
+procedure LogStringUsageToFile(const fileName: string);
+var
+  item: TStringUsage;
+  f: TFileStream;
+  b: TBytes;
+  overall: Int64;
+begin
+  f := TFileStream.Create(fileName, fmCreate);
+  b := TEncoding.UTF8.GetPreamble;
+  f.Write(b[0], Length(b));
+  try
+    overall := 0;
+    for item in LogStringUsage do
+    begin
+      if item.Value > 1 then
+      begin
+        b := TEncoding.UTF8.GetBytes(Format('%s x%d'#13#10,[item.Key, item.Value]));
+        f.Write(b[0], Length(b));
+
+        Inc(overall, (SizeOf(StrRec) + Length(item.Key) + 1) * item.Value);
+      end;
+    end;
+    b := TEncoding.UTF8.GetBytes(Format(#13#10'Overall memory wasted: %d KB'#13#10, [overall div 1024]));
+    f.Write(b[0], Length(b));
+  finally
+    f.Free;
+  end;
+end;
+
+end.

--- a/Demo/uMainForm.dfm
+++ b/Demo/uMainForm.dfm
@@ -18,11 +18,10 @@ object MainForm: TMainForm
     Left = 0
     Top = 0
     Width = 666
-    Height = 370
+    Height = 347
     Align = alClient
     ScrollBars = ssBoth
     TabOrder = 0
-    ExplicitHeight = 389
   end
   object StatusBar: TStatusBar
     Left = 0
@@ -33,9 +32,18 @@ object MainForm: TMainForm
       item
         Width = 50
       end>
-    ExplicitLeft = 344
-    ExplicitTop = 216
-    ExplicitWidth = 0
+  end
+  object CheckBox1: TCheckBox
+    AlignWithMargins = True
+    Left = 3
+    Top = 350
+    Width = 660
+    Height = 17
+    Align = alBottom
+    Caption = 
+      'Use string interning for less memory consumption (has a minor im' +
+      'pact on speed)'
+    TabOrder = 2
   end
   object MainMenu: TMainMenu
     Left = 224

--- a/Source/SimpleParser/SimpleParser.Lexer.pas
+++ b/Source/SimpleParser/SimpleParser.Lexer.pas
@@ -303,6 +303,7 @@ type
     procedure ClearDefines;
     procedure InitDefinesDefinedByCompiler;
 
+    property Buffer: PBufferRec read FBuffer;
     property CompilerDirective: string read GetCompilerDirective;
     property DirectiveParam: string read GetDirectiveParam;
     property IsJunk: Boolean read GetIsJunk;

--- a/Source/StringPool.pas
+++ b/Source/StringPool.pas
@@ -1,0 +1,112 @@
+unit StringPool;
+
+interface
+
+type
+  TStringBucket = record
+    Hash: Cardinal;
+    Value: string;
+  end;
+  PStringBucket = ^TStringBucket;
+  TStringBuckets = array of TStringBucket;
+
+  TStringPool = class
+  private
+    FBuckets: TStringBuckets;
+    FCount: Integer;
+    FGrowth: Integer;
+    FCapacity: Integer;
+    procedure Grow;
+  public
+    procedure StringIntern(var s: string);
+
+    procedure Clear;
+    property Count: Integer read FCount;
+  end;
+
+implementation
+
+{ TStringPool }
+
+procedure TStringPool.Clear;
+begin
+  SetLength(FBuckets, 0);
+  FCount := 0;
+  FGrowth := 0;
+  FCapacity := 0;
+end;
+
+procedure TStringPool.Grow;
+var
+  i, j, n: Integer;
+  oldBuckets: TStringBuckets;
+begin
+  if FCapacity = 0 then
+    FCapacity := 32
+  else
+    FCapacity := FCapacity * 2;
+  FGrowth := (FCapacity * 3) div 4 - FCount;
+
+  oldBuckets := FBuckets;
+  FBuckets := nil;
+  SetLength(FBuckets, FCapacity);
+
+  n := FCapacity - 1;
+  for i := 0 to High(oldBuckets) do
+  begin
+    if oldBuckets[i].Hash = 0 then
+      Continue;
+    j := oldBuckets[i].Hash and (FCapacity - 1);
+    while FBuckets[j].Hash <> 0 do
+      j := (j + 1) and n;
+    FBuckets[j].Hash := oldBuckets[i].Hash;
+    FBuckets[j].Value := oldBuckets[i].Value;
+  end;
+end;
+
+procedure TStringPool.StringIntern(var s: string);
+
+  function HashString(const s: string): Cardinal; inline;
+  var
+    i: Integer;
+  begin
+    // modified FNV-1a using length as seed
+    Result := Length(s);
+    for i := 1 to Result do
+      Result := (Result xor Ord(s[i])) * 16777619;
+  end;
+
+var
+  hash: Cardinal;
+  i: Integer;
+  bucket: PStringBucket;
+begin
+  if s = '' then
+    Exit;
+
+  if FGrowth = 0 then
+    Grow;
+
+  hash := HashString(s) shr 6;
+  i := hash and (FCapacity - 1);
+
+  repeat
+    bucket := @FBuckets[i];
+    if (bucket.Hash = hash) and (bucket.Value = s) then
+    begin
+      s := bucket.Value;
+      Exit;
+    end
+    else if bucket.Hash = 0 then
+    begin
+      bucket.Hash := hash;
+      bucket.Value := s;
+      Inc(FCount);
+      Dec(FGrowth);
+      Exit;
+    end;
+    i := (i + 1) and (FCapacity - 1);
+  until False;
+end;
+
+end.


### PR DESCRIPTION
I added the possibility to activate string interning.

My goal was to be as unintrusive with this feature as possible so I added an event that you can attach to the TPasSyntaxTreeBuilder. If you pass nil it behaves as it currently does (possibly allocating hundreds and thousands of strings with identical content).

To keep this all inside the TPasSyntaxTreeBuilder and not in the underlying lexer I added a wrapper for the lexer to call the interning in the GetToken method.

In the demo you can see how speed and memory consumption changes with or without the interning.
Optionally for diagnostic purpose you can remove the comments from LogStringUsageToFile and let it output all duplicate strings in the memory manager (using FastMM4) - this may take a few seconds.
