### PR TITLE
Added support for scoped enums. Fixes #184

### DIFF
--- a/Source/DelphiAST.pas
+++ b/Source/DelphiAST.pas
@@ -1197,9 +1197,14 @@ begin
 end;
 
 procedure TPasSyntaxTreeBuilder.EnumeratedType;
+var
+  TypeNode: TSyntaxNode;
 begin
-  FStack.Push(ntType).SetAttribute(anName, AttributeValues[atEnum]);
+  TypeNode := FStack.Push(ntType);
   try
+    TypeNode.SetAttribute(anName, AttributeValues[atEnum]);
+    if ScopedEnums then
+      TypeNode.SetAttribute(anVisibility, 'scoped');
     inherited;
   finally
     FStack.Pop;

--- a/Source/SimpleParser/SimpleParser.Lexer.Types.pas
+++ b/Source/SimpleParser/SimpleParser.Lexer.Types.pas
@@ -218,6 +218,7 @@ type
     ptRoundOpen,
     ptRunError,
     ptSafeCall,
+    ptScopedEnumsDirect,
     ptSealed,
     ptSemiColon,
     ptSet,
@@ -318,6 +319,7 @@ begin
     ptEndIfDirect,
     ptIfOptDirect,
     ptDefineDirect,
+    ptScopedEnumsDirect,
     ptUndefDirect];
 end;
 

--- a/Source/SimpleParser/SimpleParser.pas
+++ b/Source/SimpleParser/SimpleParser.pas
@@ -206,6 +206,7 @@ type
     procedure VariableTail;
     function GetInRound: Boolean;
     function GetUseDefines: Boolean;
+    function GetScopedEnums: Boolean;
     procedure SetUseDefines(const Value: Boolean);
     procedure SetIncludeHandler(IncludeHandler: IIncludeHandler);
     function GetOnComment: TCommentEvent;
@@ -580,6 +581,7 @@ type
     property LastNoJunkLen: Integer read FLastNoJunkLen;
 
     property UseDefines: Boolean read GetUseDefines write SetUseDefines;
+    property ScopedEnums: Boolean read GetScopedEnums;
     property IncludeHandler: IIncludeHandler write SetIncludeHandler;
   end;
 
@@ -992,6 +994,11 @@ end;
 function TmwSimplePasPar.GetUseDefines: Boolean;
 begin
   Result := FLexer.UseDefines;
+end;
+
+function TmwSimplePasPar.GetScopedEnums: Boolean;
+begin
+  Result := FLexer.ScopedEnums;
 end;
 
 procedure TmwSimplePasPar.GotoStatement;


### PR DESCRIPTION
With this PR scoped enums can be identified by the additional visibility attribute. This attribute is only present in the rare case of a scoped enum.  