### PR TITLE
don't $I files when inside skipped $IFDEF/$IF

### DIFF
--- a/Source/SimpleParser/SimpleParser.Lexer.pas
+++ b/Source/SimpleParser/SimpleParser.Lexer.pas
@@ -1595,7 +1595,7 @@ begin
       begin
 //        if Assigned(FOnIncludeDirect) then
 //          FOnIncludeDirect(Self);
-        if Assigned(FIncludeHandler) then
+        if Assigned(FIncludeHandler) and (FDefineStack = 0) then
           IncludeFile
         else
           Next;


### PR DESCRIPTION
If $INCLUDE/$I is found while in the $IF(N)DEF/$IF part which is being skipped (undefined conditional etc), include is ignored.

This speeds up parsing (especially if include file has to be found in a long search path) and makes the parser more compatible with Delphi which ignores $INCLUDE statements inside skipped blocks.

Example:

{$IFDEF DELPHI}
{$I delphi.inc}
{$ELSE}
{$I notdelphi.inc}
{$ENDIF}

When parsing for Delphi (DELPHI is defined), delphi.inc is included and notdelphi.inc is skipped.

Without this fix both .inc files are included and parsed.