### PR TITLE
Generic Methods

### DIFF
--- a/Source/DelphiAST.pas
+++ b/Source/DelphiAST.pas
@@ -1461,19 +1461,28 @@ end;
 
 procedure TPasSyntaxTreeBuilder.FunctionProcedureName;
 var
-  ChildNode, NameNode, TypeParam, TypeNode, Temp: TSyntaxNode;
+  ChildNode, NameNode, TypeParamsNode, TypeParam, TypeNode, Temp: TSyntaxNode;
   FullName, TypeParams: string;
 begin
   FStack.Push(ntName);
+  TypeParamsNode := Nil;
   NameNode := FStack.Peek;
   try
     inherited;
+    TypeParams := '';
     for ChildNode in NameNode.ChildNodes do
     begin
+      if TypeParams <> '' then
+        FullName := FullName + '<' + TypeParams + '>';
+
+      TypeParams := '';
+
+      TypeParamsNode := Nil;
       if ChildNode.Typ = ntTypeParams then
       begin
+        TypeParamsNode := ChildNode;
         TypeParams := '';
-
+        
         for TypeParam in ChildNode.ChildNodes do
         begin
           TypeNode := TypeParam.FindNode(ntType);
@@ -1485,7 +1494,6 @@ begin
           end;
         end;
 
-        FullName := FullName + '<' + TypeParams + '>';
         Continue;
       end;
 
@@ -1498,6 +1506,11 @@ begin
     Temp := FStack.Peek;
     DoHandleString(FullName);
     Temp.SetAttribute(anName, FullName);
+    if Assigned(TypeParamsNode) then
+    begin
+      NameNode.ExtractChild(TypeParamsNode);
+      Temp.AddChild(TypeParamsNode);      
+    end;
     Temp.DeleteChild(NameNode);
   end;
 end;

--- a/Source/SimpleParser/SimpleParser.pas
+++ b/Source/SimpleParser/SimpleParser.pas
@@ -2048,7 +2048,7 @@ begin
   else
     begin
       Expected(ptColon);
-      ReturnType; 
+      ReturnType;
       FunctionProcedureBlock;
     end;
   end;
@@ -2119,7 +2119,7 @@ begin
   end;
 
   if HasBlock then
-  begin 
+  begin
     case TokenID of
       ptAsm:
         begin
@@ -4412,7 +4412,7 @@ begin
 end;
 
 procedure TmwSimplePasPar.TypeKind;
-begin 
+begin
   case TokenID of
     ptAsciiChar, ptFloat, ptIntegerConst, ptMinus, ptNil, ptPlus, ptStringConst, ptConst:
       begin
@@ -4678,7 +4678,7 @@ begin
   else
     begin
       SynError(InvalidProcedureDeclarationSection);
-    end; 
+    end;
   end;
 end;
 


### PR DESCRIPTION
Generic type parameters are plain text part of method names. With this PR type parameters of methods are part of AST in the same way as they are in type declarations.

Code: 
```Delphi  
TGen<T> = class
  procedure Generate<T2>;
end;
````

AST:
```XML
<METHOD begin_line="15" begin_col="5" end_line="16" end_col="3" kind="procedure" name="Generate">
    <TYPEPARAMS line="15" col="23">
        <TYPEPARAM line="15" col="24">
            <TYPE line="15" col="24" name="T2"/>
        </TYPEPARAM>
    </TYPEPARAMS>
</METHOD>
```

We may need to discuss how the implementations of generic methods are shown in AST. 

Code:
```Delphi  
procedure TGen<T>.Generate<T2>;
begin
  
end;
```

Currently the method's name attribute contains the entire method name `TGen<T>.Generate<T2>`.  This is not the most elegant solution as someone would need to parse the name in order to get the generic type parameters and the name of the current class.
I didn't want to break existing projects using DelphiAST so I decided to remove only the method's generic parameters from the name and keep the rest of it untouched: The type name including its generic parameters remains still plain text. 

AST:
```XML
    <METHOD begin_line="170" begin_col="1" end_line="175" end_col="1" name="TGen&lt;T&gt;.Generate" kind="procedure">
      <TYPEPARAMS line="170" col="27">
        <TYPEPARAM line="170" col="28">
          <TYPE line="170" col="28" name="T2"/>
        </TYPEPARAM>
      </TYPEPARAMS>
      <STATEMENTS begin_line="171" begin_col="1" end_line="173" end_col="4"/>
    </METHOD>
```