### PR TITLE
Class variables have class attribute

### DIFF
--- a/Source/DelphiAST.pas
+++ b/Source/DelphiAST.pas
@@ -114,6 +114,7 @@ type
     procedure ClassProperty; override;
     procedure ClassReferenceType; override;
     procedure ClassType; override;
+    procedure ClassVar; override;
     procedure CompoundStatement; override;
     procedure ConstParameter; override;
     procedure ConstantDeclaration; override;
@@ -887,6 +888,17 @@ begin
   finally
     MoveMembersToVisibilityNodes(FStack.Pop);
   end;
+end;
+
+procedure TPasSyntaxTreeBuilder.ClassVar;
+var
+  FieldNode: TSyntaxNode;
+begin
+  inherited;
+
+  for FieldNode in FStack.Peek.ChildNodes do
+    if FieldNode.Typ = ntField then
+      FieldNode.SetAttribute(anClass, AttributeValues[atTrue]);
 end;
 
 procedure TPasSyntaxTreeBuilder.MoveMembersToVisibilityNodes(TypeNode: TSyntaxNode);

--- a/Source/SimpleParser/SimpleParser.pas
+++ b/Source/SimpleParser/SimpleParser.pas
@@ -274,6 +274,7 @@ type
     procedure ClassReferenceType; virtual;
     procedure ClassType; virtual;
     procedure ClassTypeEnd; virtual;
+    procedure ClassVar; virtual;
     procedure ClassVisibility; virtual;
     procedure CompoundStatement; virtual;
     procedure ConstantColon; virtual;
@@ -3696,6 +3697,11 @@ begin
   Expected(ptRoundClose);
 end;
 
+procedure TmwSimplePasPar.ClassVar;
+begin
+  ClassField;
+end;
+
 procedure TmwSimplePasPar.ClassVisibility;
 var
   IsStrict: boolean;
@@ -3850,7 +3856,7 @@ begin
         NextToken;
         while (TokenID = ptIdentifier) and (ExID = ptUnknown) do
         begin
-          ClassField;
+          ClassVar;
           Semicolon;
         end;
       end;


### PR DESCRIPTION
It's impossible to know whether a field is a class var. With this PR the `class` attribute is added to class variables. It's similar to class methods and class properties.