### PR TITLE
Class variables have class attribute (Fixed version)

### DIFF
--- a/Source/DelphiAST.pas
+++ b/Source/DelphiAST.pas
@@ -114,6 +114,7 @@ type
     procedure ClassProperty; override;
     procedure ClassReferenceType; override;
     procedure ClassType; override;
+    procedure ClassVar; override;
     procedure CompoundStatement; override;
     procedure ConstParameter; override;
     procedure ConstantDeclaration; override;
@@ -887,6 +888,17 @@ begin
   finally
     MoveMembersToVisibilityNodes(FStack.Pop);
   end;
+end;
+
+procedure TPasSyntaxTreeBuilder.ClassVar;
+var
+  FieldNode: TSyntaxNode;
+begin
+  inherited;
+
+  for FieldNode in FStack.Peek.ChildNodes do
+    if FieldNode.Typ = ntField then
+      FieldNode.SetAttribute(anClass, AttributeValues[atTrue]);
 end;
 
 procedure TPasSyntaxTreeBuilder.MoveMembersToVisibilityNodes(TypeNode: TSyntaxNode);

--- a/Source/SimpleParser/SimpleParser.pas
+++ b/Source/SimpleParser/SimpleParser.pas
@@ -274,6 +274,7 @@ type
     procedure ClassReferenceType; virtual;
     procedure ClassType; virtual;
     procedure ClassTypeEnd; virtual;
+    procedure ClassVar; virtual;
     procedure ClassVisibility; virtual;
     procedure CompoundStatement; virtual;
     procedure ConstantColon; virtual;
@@ -3696,6 +3697,11 @@ begin
   Expected(ptRoundClose);
 end;
 
+procedure TmwSimplePasPar.ClassVar;
+begin
+  ClassField;
+end;
+
 procedure TmwSimplePasPar.ClassVisibility;
 var
   IsStrict: boolean;
@@ -3850,7 +3856,7 @@ begin
         NextToken;
         while (TokenID = ptIdentifier) and (ExID = ptUnknown) do
         begin
-          ClassField;
+          ClassVar;
           Semicolon;
         end;
       end;


### PR DESCRIPTION
My first attempt marked all fields within the same visibility node as class variables. I've fixed it now.

So this code:

```Delphi
  TStatic = class
  public
    FNotStaticButInTheSameSection: Integer; // <-- This was marked as class field in the first attempt
    class var FClassVar, 
      FClassVar2: String; 
      FClassVar3: integer;
    class property ClassProp: String read FClassVar;
  public
    FInstanceVar: String;
    property InstanceProp: String read FInstanceVar;
  end;
```

Leads to this AST:

```XML
      <TYPEDECL begin_line="309" begin_col="3" end_line="319" end_col="6" name="TStatic">
        <TYPE line="309" col="13" type="class" class="true">
          <PUBLIC line="310" col="3" visibility="true">
            <FIELD line="311" col="5">
              <NAME line="311" col="5" value="FNotStaticButInTheSameSection"/>
              <TYPE line="311" col="36" name="Integer"/>
            </FIELD>
            <FIELD line="312" col="15" class="true">
              <NAME line="312" col="15" value="FClassVar"/>
              <TYPE line="313" col="19" name="String"/>
            </FIELD>
            <FIELD line="313" col="7" class="true">
              <NAME line="313" col="7" value="FClassVar2"/>
              <TYPE line="313" col="19" name="String"/>
            </FIELD>
            <FIELD line="314" col="7" class="true">
              <NAME line="314" col="7" value="FClassVar3"/>
              <TYPE line="314" col="19" name="integer"/>
            </FIELD>
            <PROPERTY line="315" col="5" class="true" name="ClassProp">
              <TYPE line="315" col="31" name="String"/>
              <READ line="315" col="38">
                <IDENTIFIER line="315" col="43" name="FClassVar"/>
              </READ>
            </PROPERTY>
          </PUBLIC>
          <PUBLIC line="316" col="3" visibility="true">
            <FIELD line="317" col="5">
              <NAME line="317" col="5" value="FInstanceVar"/>
              <TYPE line="317" col="19" name="String"/>
            </FIELD>
            <PROPERTY line="318" col="5" name="InstanceProp">
              <TYPE line="318" col="28" name="String"/>
              <READ line="318" col="35">
                <IDENTIFIER line="318" col="40" name="FInstanceVar"/>
              </READ>
            </PROPERTY>
          </PUBLIC>
        </TYPE>
      </TYPEDECL>

```