### PR TITLE
In the AST the descendant nodes after the "absolute" node and before the "identifier" node was deleted.

### DIFF
--- a/Source/DelphiAST.Consts.pas
+++ b/Source/DelphiAST.Consts.pas
@@ -5,6 +5,7 @@ interface
 type
   TSyntaxNodeType = (
     ntUnknown,
+    ntAbsolute,
     ntAdd,
     ntAddr,
     ntAlignmentParam,
@@ -158,6 +159,7 @@ type
 const
   SyntaxNodeNames: array [TSyntaxNodeType] of string = (
     'unknown',
+    'absolute',
     'add',
     'addr',
     'alignmentparam',

--- a/Source/DelphiAST.pas
+++ b/Source/DelphiAST.pas
@@ -216,6 +216,7 @@ type
     procedure UnitId; override;
     procedure UsesClause; override;
     procedure UsedUnitName; override;
+    procedure VarAbsolute; override;
     procedure VarDeclaration; override;
     procedure VarName; override;
     procedure VarParameter; override;
@@ -2522,6 +2523,16 @@ begin
   end;
 end;
 
+procedure TPasSyntaxTreeBuilder.VarAbsolute;
+begin
+  FStack.Push(ntAbsolute);
+  try
+    inherited;
+  finally
+    FStack.Pop;
+  end;
+end;
+
 procedure TPasSyntaxTreeBuilder.VarDeclaration;
 begin
   FStack.Push(ntVariables);
@@ -2573,27 +2584,27 @@ end;
 procedure TPasSyntaxTreeBuilder.RearrangeVarSection(const VarSect: TSyntaxNode);
 var
   Temp: TSyntaxNode;
-  VarList, Variable, TypeInfo, ValueInfo: TSyntaxNode;
+  VarList, Variable, TypeInfo, ValueInfo, AbsoluteInfo: TSyntaxNode;
 begin
   for VarList in VarSect.ChildNodes do
   begin
     TypeInfo := VarList.FindNode(ntType);
     ValueInfo := VarList.FindNode(ntValue);
+    AbsoluteInfo := VarList.FindNode(ntAbsolute);
     for Variable in VarList.ChildNodes do
     begin
       if Variable.Typ <> ntName then
         Continue;
-
       Temp := FStack.Push(ntVariable);
       try
         Temp.AssignPositionFrom(Variable);
-
         FStack.AddChild(Variable.Clone);
         if Assigned(TypeInfo) then
           FStack.AddChild(TypeInfo.Clone);
-
         if Assigned(ValueInfo) then
           FStack.AddChild(ValueInfo.Clone);
+        if Assigned(AbsoluteInfo) then
+          FStack.AddChild(AbsoluteInfo.Clone);
       finally
         FStack.Pop;
       end;

--- a/Source/DelphiAST.pas
+++ b/Source/DelphiAST.pas
@@ -2584,13 +2584,12 @@ end;
 procedure TPasSyntaxTreeBuilder.RearrangeVarSection(const VarSect: TSyntaxNode);
 var
   Temp: TSyntaxNode;
-  VarList, Variable, TypeInfo, ValueInfo, AbsoluteInfo: TSyntaxNode;
+  VarList, Variable, TypeInfo, ValueInfo: TSyntaxNode;
 begin
   for VarList in VarSect.ChildNodes do
   begin
     TypeInfo := VarList.FindNode(ntType);
     ValueInfo := VarList.FindNode(ntValue);
-    AbsoluteInfo := VarList.FindNode(ntAbsolute);
     for Variable in VarList.ChildNodes do
     begin
       if Variable.Typ <> ntName then
@@ -2602,9 +2601,13 @@ begin
         if Assigned(TypeInfo) then
           FStack.AddChild(TypeInfo.Clone);
         if Assigned(ValueInfo) then
-          FStack.AddChild(ValueInfo.Clone);
-        if Assigned(AbsoluteInfo) then
-          FStack.AddChild(AbsoluteInfo.Clone);
+          FStack.AddChild(ValueInfo.Clone)
+        else
+        begin
+          Temp := VarList.FindNode([ntAbsolute, ntValue, ntExpression, ntIdentifier]);
+          if Assigned(Temp) then
+            FStack.AddChild(ntAbsolute).AddChild(Temp.Clone);
+        end;
       finally
         FStack.Pop;
       end;


### PR DESCRIPTION
In the AST the descendant nodes after the "absolute" node and before the "identifier" node was deleted.