### PR TITLE
Update IIncludeHandler interface

### DIFF
--- a/Demo/Parser/uMainForm.pas
+++ b/Demo/Parser/uMainForm.pas
@@ -50,7 +50,8 @@ type
     FPath: string;
   public
     constructor Create(const Path: string);
-    function GetIncludeFileContent(const FileName: string): string;
+    function GetIncludeFileContent(const ParentFileName, IncludeName: string;
+      out Content: string; out FileName: string): Boolean;
   end;
 
 {$IFNDEF FPC}
@@ -135,20 +136,24 @@ begin
   FPath := Path;
 end;
 
-function TIncludeHandler.GetIncludeFileContent(const FileName: string): string;
+function TIncludeHandler.GetIncludeFileContent(const ParentFileName, IncludeName: string;
+  out Content: string; out FileName: string): Boolean;
 var
   FileContent: TStringList;
 begin
   FileContent := TStringList.Create;
   try
-    if not FileExists(TPath.Combine(FPath, FileName)) then
+    if not FileExists(TPath.Combine(FPath, IncludeName)) then
     begin
-      Result := '';
+      Result := False;
       Exit;
     end;
 
-    FileContent.LoadFromFile(TPath.Combine(FPath, FileName));
-    Result := FileContent.Text;
+    FileContent.LoadFromFile(TPath.Combine(FPath, IncludeName));
+    Content := FileContent.Text;
+    FileName := TPath.Combine(FPath, IncludeName);
+
+    Result := True;
   finally
     FileContent.Free;
   end;

--- a/Source/DelphiAST.ProjectIndexer.pas
+++ b/Source/DelphiAST.ProjectIndexer.pas
@@ -80,7 +80,8 @@ type
     public
       constructor Create(indexer: TProjectIndexer; includeCache: TIncludeCache;
         problemList: TProblems; const currentFile: string);
-      function  GetIncludeFileContent(const fileName: string): string;
+      function  GetIncludeFileContent(const ParentFileName, FileName: string; out Content: string;
+        out filePath: string): Boolean;
     end;
 
   var
@@ -558,10 +559,9 @@ begin
 end;
 
 function TProjectIndexer.TIncludeHandler.GetIncludeFileContent(
-  const fileName: string): string;
+  const ParentFileName, fileName: string; out Content: string; out filePath: string): Boolean;
 var
   errorMsg   : string;
-  filePath   : string;
   fileStream : TStringStream;
   fName      : string;
   includeInfo: TIncludeInfo;
@@ -576,29 +576,37 @@ begin
 
   key := fName + #13 + FUnitFileFolder;
   if FIncludeCache.TryGetValue(key, includeInfo) then
-    Exit(includeInfo.Content);
+  begin
+    Content := includeInfo.Content;
+    filePath := includeInfo.FileName;
+    Exit(True);
+  end;
 
   if not FIndexer.FindFile(fName, FUnitFileFolder, filePath) then begin
     FProblems.LogProblem(ptCantFindFile, fName, 'Source folder: ' + FUnitFileFolder);
     includeInfo.FileName := '';
     includeInfo.Content := '';
     FIncludeCache.Add(key, includeInfo);
-    Exit('');
+    Exit(False);
   end;
 
   if FIncludeCache.TryGetValue(filePath, includeInfo) then
-    Exit(includeInfo.Content);
+  begin
+    Content := includeInfo.Content;
+    Exit(True);
+  end;
 
   if not TProjectIndexer.SafeOpenFileStream(filePath, fileStream, errorMsg) then begin
     FProblems.LogProblem(ptCantOpenFile, filePath, errorMsg);
-    Result := ''
+    Result := False;
   end
   else try
-    Result := fileStream.DataString;
+    Content := fileStream.DataString;
+    Result := True;
   finally FreeAndNil(fileStream); end;
 
   includeInfo.FileName := filePath;
-  includeInfo.Content := Result;
+  includeInfo.Content := Content;
   FIncludeCache.Add(fName + #13 + FUnitFileFolder, includeInfo);
   includeInfo.FileName := '';
   FIncludeCache.Add(filePath, includeInfo);

--- a/Source/SimpleParser/SimpleParser.Lexer.Types.pas
+++ b/Source/SimpleParser/SimpleParser.Lexer.Types.pas
@@ -282,7 +282,8 @@ type
   EIncludeError = class(Exception);
   IIncludeHandler = interface
     ['{C5F20740-41D2-43E9-8321-7FE5E3AA83B6}']
-    function GetIncludeFileContent(const FileName: string): string;
+    function GetIncludeFileContent(const ParentFileName, IncludeName: string;
+      out Content: string; out FileName: string): Boolean;
   end;
 
 function TokenName(Value: TptTokenKind): string;

--- a/Source/SimpleParser/SimpleParser.Lexer.pas
+++ b/Source/SimpleParser/SimpleParser.Lexer.pas
@@ -2545,25 +2545,29 @@ end;
 
 procedure TmwBasePasLex.IncludeFile;
 var
-  IncludeFileName, IncludeDirective, Content: string;
+  IncludeName, IncludeDirective, Content, FileName: string;
   NewBuffer: PBufferRec;
 begin
   IncludeDirective := Token;
-  IncludeFileName := GetIncludeFileNameFromToken(IncludeDirective);
-  Content := FIncludeHandler.GetIncludeFileContent(IncludeFileName) + #13#10;
+  IncludeName := GetIncludeFileNameFromToken(IncludeDirective);
 
-  New(NewBuffer);
-  NewBuffer.SharedBuffer := False;
-  NewBuffer.Next := FBuffer;
-  NewBuffer.LineNumber := 0;
-  NewBuffer.LinePos := 0;
-  NewBuffer.Run := 0;
-  NewBuffer.FileName := IncludeFileName;
-  GetMem(NewBuffer.Buf, (Length(Content) + 1) * SizeOf(Char));
-  StrPCopy(NewBuffer.Buf, Content);
-  NewBuffer.Buf[Length(Content)] := #0;
+  if FIncludeHandler.GetIncludeFileContent(FBuffer.FileName, IncludeName, Content, FileName) then
+  begin
+    Content := Content + #13#10;
 
-  FBuffer := NewBuffer;
+    New(NewBuffer);
+    NewBuffer.SharedBuffer := False;
+    NewBuffer.Next := FBuffer;
+    NewBuffer.LineNumber := 0;
+    NewBuffer.LinePos := 0;
+    NewBuffer.Run := 0;
+    NewBuffer.FileName := FileName;
+    GetMem(NewBuffer.Buf, (Length(Content) + 1) * SizeOf(Char));
+    StrPCopy(NewBuffer.Buf, Content);
+    NewBuffer.Buf[Length(Content)] := #0;
+
+    FBuffer := NewBuffer;
+  end;
 
   Next;
 end;

--- a/Test/uMainForm.pas
+++ b/Test/uMainForm.pas
@@ -14,6 +14,15 @@ uses
   SimpleParser.Lexer.Types;
 
 type
+  TIncludeHandler = class(TInterfacedObject, IIncludeHandler)
+  private
+    FPath: string;
+  public
+    constructor Create(const Path: string);
+    function GetIncludeFileContent(const ParentFileName, IncludeName: string;
+      out Content: string; out FileName: string): Boolean;
+  end;
+
   TForm2 = class(TForm)
     memLog: TMemo;
     btnRun: TButton;
@@ -22,14 +31,6 @@ type
     { Private declarations }
   public
     { Public declarations }
-  end;
-
-  TIncludeHandler = class(TInterfacedObject, IIncludeHandler)
-  private
-    FPath: string;
-  public
-    constructor Create(const Path: string);
-    function GetIncludeFileContent(const FileName: string): string;
   end;
 
 var
@@ -82,14 +83,17 @@ begin
   FPath := Path;
 end;
 
-function TIncludeHandler.GetIncludeFileContent(const FileName: string): string;
+function TIncludeHandler.GetIncludeFileContent(const ParentFileName, IncludeName: string;
+  out Content: string; out FileName: string): Boolean;
 var
   FileContent: TStringList;
 begin
   FileContent := TStringList.Create;
   try
-    FileContent.LoadFromFile(TPath.Combine(FPath, FileName));
-    Result := FileContent.Text;
+    FileName := TPath.Combine(FPath, IncludeName);
+    FileContent.LoadFromFile(FileName);
+    Content := FileContent.Text;
+    Result := True;
   finally
     FileContent.Free;
   end;


### PR DESCRIPTION
In order to provide more information for `IIncludeHandler.GetIncludeFileContent()` implementation, I've made few changes.

This is needed in to be able to find .inc files in complex cases.

For example, you include `jcl.inc`. It's in your search path. So you can easily find it. Then `jcl.inc` has this line:
```
{$I jedi\jedi.inc} // Pull in the JCL/J-VCL shared directives
```
`jedi\jedi.inc` path is relative to `jcl.inc`. Thus order to find it, `IIncludeHandler` implementation needs to know full path to `jcl.inc`. That's why `ParentFileName` is passed to `GetIncludeFileContent()`.