### PR TITLE
Changing the for-in loop variable expectation

### DIFF
--- a/Source/SimpleParser/SimpleParser.pas
+++ b/Source/SimpleParser/SimpleParser.pas
@@ -2203,7 +2203,7 @@ begin
     InlineVarDeclaration;
   end
   else
-    QualifiedIdentifier;
+    Variable;
 
   if Lexer.TokenID = ptAssign then
   begin


### PR DESCRIPTION
Changing from QualifiedIdentifier to Variable allows the for-in loop to
have this syntax:

for TSomeType(VarName) in Collection do

So then the VarName can be of a different type than the Collection item
type and be typecast to match the item type. The above syntax compiles
in Delphi.