### PR TITLE
Allow shared read access to parsed files

### DIFF
--- a/Source/DelphiAST.ProjectIndexer.pas
+++ b/Source/DelphiAST.ProjectIndexer.pas
@@ -457,7 +457,7 @@ var
 begin
   Result := true;
   try
-    readStream := TFileStream.Create(fileName, fmOpenRead);
+    readStream := TFileStream.Create(fileName, fmOpenRead or fmShareDenyWrite);
   except
     on E: EFCreateError do begin
       errorMsg := E.Message;


### PR DESCRIPTION
We had concurrency issues when running several instances of a small tool based on DelphiAST in parallel.
After running the tool with this fix for ten work days, I can say that the concurrency issues are gone. 
Perhaps this also resolves the concurrency issues that I have observed with FixInsight? ;)