### PR TITLE
Add support for alignment on records

### DIFF
--- a/Source/DelphiAST.Consts.pas
+++ b/Source/DelphiAST.Consts.pas
@@ -153,7 +153,8 @@ type
     anReintroduce,
     anOverload,
     anAbstract,
-    anInline
+    anInline,
+    anAlign
   );
 
 const
@@ -307,7 +308,8 @@ const
     'reintroduce',
     'overload',
     'abstract',
-    'inline'
+    'inline',
+    'align'
   );
 
 implementation

--- a/Source/DelphiAST.pas
+++ b/Source/DelphiAST.pas
@@ -177,6 +177,7 @@ type
     procedure PropertyName; override;
     procedure PropertyParameterList; override;
     procedure RaiseStatement; override;
+    procedure RecordAlignValue; override;
     procedure RecordConstraint; override;
     procedure RecordFieldConstant; override;
     procedure RecordType; override;
@@ -991,6 +992,12 @@ begin
   finally
     FStack.Pop;
   end;
+end;
+
+procedure TPasSyntaxTreeBuilder.RecordAlignValue;
+begin
+  FStack.Peek.SetAttribute(anAlign, Lexer.Token);
+  inherited;
 end;
 
 procedure TPasSyntaxTreeBuilder.ConstSection;

--- a/Source/SimpleParser/SimpleParser.Lexer.Types.pas
+++ b/Source/SimpleParser/SimpleParser.Lexer.Types.pas
@@ -54,6 +54,7 @@ type
     ptAbstract,
     ptAdd,
     ptAddressOp,
+    ptAlign,
     ptAmpersand,
     ptAnd,
     ptAnsiComment,

--- a/Source/SimpleParser/SimpleParser.Lexer.pas
+++ b/Source/SimpleParser/SimpleParser.Lexer.pas
@@ -757,7 +757,8 @@ function TmwBasePasLex.Func43: TptTokenKind;
 begin
   Result := ptIdentifier;
   if KeyComp('Int64') then FExID := ptInt64
-  else if KeyComp('local') then FExID := ptLocal;
+  else if KeyComp('local') then FExID := ptLocal
+  else if KeyComp('align') then Result := ptAlign;
 end;
 
 function TmwBasePasLex.Func44: TptTokenKind;

--- a/Source/SimpleParser/SimpleParser.pas
+++ b/Source/SimpleParser/SimpleParser.pas
@@ -437,6 +437,8 @@ type
     procedure ReadAccessIdentifier; virtual;
     procedure RealIdentifier; virtual;
     procedure RealType; virtual;
+    procedure RecordAlign; virtual;
+    procedure RecordAlignValue; virtual;
     procedure RecordConstant; virtual;
     procedure RecordConstraint; virtual;
     procedure RecordFieldConstant; virtual;
@@ -3304,6 +3306,7 @@ begin
   Expected(ptEnd);
 
   ClassTypeEnd;
+  RecordAlign;
 end;
 
 procedure TmwSimplePasPar.FileType;
@@ -4309,6 +4312,20 @@ begin
       VariableReference;
     end;
   end;
+end;
+
+procedure TmwSimplePasPar.RecordAlign;
+begin
+  if TokenID = ptAlign then
+  begin
+    Expected(ptAlign);
+    RecordAlignValue;
+  end;
+end;
+
+procedure TmwSimplePasPar.RecordAlignValue;
+begin
+  Expected(ptIntegerConst);
 end;
 
 procedure TmwSimplePasPar.RecordFieldConstant;

--- a/Test/Snippets/alignedrecords.pas
+++ b/Test/Snippets/alignedrecords.pas
@@ -1,0 +1,25 @@
+unit managedrecords;
+
+interface
+
+type
+  TMyRecord = record
+    Value: Integer;
+    class operator Initialize (out Dest: TMyRecord);
+    class operator Finalize(var Dest: TMyRecord);
+  end align 8;
+
+implementation
+	
+class operator TMyRecord.Initialize (out Dest: TMyRecord);
+begin
+  Dest.Value := 10;
+  Log('created' + IntToHex (Integer(Pointer(@Dest))));
+end;
+ 
+class operator TMyRecord.Finalize(var Dest: TMyRecord);
+begin
+  Log('destroyed' + IntToHex (Integer(Pointer(@Dest))));
+end;
+
+end.

--- a/Test/Snippets/nonalignedrecords.pas
+++ b/Test/Snippets/nonalignedrecords.pas
@@ -1,0 +1,25 @@
+unit managedrecords;
+
+interface
+
+type
+  TMyRecord = record
+    Value: Integer;
+    class operator Initialize (out Dest: TMyRecord);
+    class operator Finalize(var Dest: TMyRecord);
+  end;
+
+implementation
+	
+class operator TMyRecord.Initialize (out Dest: TMyRecord);
+begin
+  Dest.Value := 10;
+  Log('created' + IntToHex (Integer(Pointer(@Dest))));
+end;
+ 
+class operator TMyRecord.Finalize(var Dest: TMyRecord);
+begin
+  Log('destroyed' + IntToHex (Integer(Pointer(@Dest))));
+end;
+
+end.


### PR DESCRIPTION
I figured out the issue I had with resolving the alignment attribute. In the parser, I had to create 2 additional virtual methods: RecordAlignment and RecordAlignmentValue.

I've added 2 snippets, one with and without alignment.
