### PR TITLE
Log encoding errors as problems

### DIFF
--- a/Source/DelphiAST.ProjectIndexer.pas
+++ b/Source/DelphiAST.ProjectIndexer.pas
@@ -457,7 +457,7 @@ var
 begin
   Result := true;
   try
-    readStream := TFileStream.Create(fileName, fmOpenRead);
+    readStream := TFileStream.Create(fileName, fmOpenRead or fmShareDenyWrite);
   except
     on E: EFCreateError do begin
       errorMsg := E.Message;

--- a/Source/DelphiAST.ProjectIndexer.pas
+++ b/Source/DelphiAST.ProjectIndexer.pas
@@ -509,6 +509,9 @@ begin
           FProblems.LogProblem(ptCantParseFile, fileName,
             Format('Line %d, Column %d: %s', [E.Line, E.Col, E.Message]));
         end;
+        on E: EEncodingError do begin
+          FProblems.LogProblem(ptCantParseFile, fileName, E.Message);
+        end;
       end;
     finally FreeAndNil(builder); end;
   finally FreeAndNil(fileStream); end;


### PR DESCRIPTION
When parsing projects with DelphiAST I had the problem that there were some files with broken encoding. These only resulted in a general exception without telling me the name of the affected file.

This PR adds logging for EEncodingError Exceptions, so they can be listed when the parsing is done.

The output of my test application:
```
2 problems
2 D:\Projects\FileA.pas: Keine Zuordnung für Unicode-Zeichen in der Multibyte-Zielcodeseite vorhanden
2 D:\Projects\FileB.Ini.pas: Keine Zuordnung für Unicode-Zeichen in der Multibyte-Zielcodeseite vorhanden
```