### PR TITLE
Fix Multiline parsing error #336

### DIFF
--- a/Source/SimpleParser/SimpleParser.Lexer.pas
+++ b/Source/SimpleParser/SimpleParser.Lexer.pas
@@ -2365,8 +2365,8 @@ begin
         else
           if NewLine and (FBuffer.Buf[FBuffer.Run] <> #9) and (FBuffer.Buf[FBuffer.Run] <> #32) then
             NewLine := False;
+          Inc(FBuffer.Run);
       end;
-      Inc(FBuffer.Run);
     until False;
   end
   else


### PR DESCRIPTION
The `Inc(FBuffer.Run); `after the `case` belongs to the `else` of the `case` statement. Otherwise the first character of a each line is skipped. That has serious consequences when the closing triple quotes are at the beginning of a line.