### PR TITLE
Fix parsing expression after record align

### DIFF
--- a/Source/SimpleParser/SimpleParser.pas
+++ b/Source/SimpleParser/SimpleParser.pas
@@ -4382,7 +4382,7 @@ begin
   begin
     NextToken;
     if TokenID = ptRoundOpen then
-      SimpleExpression
+      ConstantExpression
     else
       RecordAlignValue;
   end;

--- a/Source/SimpleParser/SimpleParser.pas
+++ b/Source/SimpleParser/SimpleParser.pas
@@ -4381,7 +4381,10 @@ begin
   if ExID = ptAlign then
   begin
     NextToken;
-    RecordAlignValue;
+    if TokenID = ptRoundOpen then
+      SimpleExpression
+    else
+      RecordAlignValue;
   end;
 end;
 


### PR DESCRIPTION
See [An align after a record can be an expression #339](https://github.com/RomanYankovsky/DelphiAST/issues/339)